### PR TITLE
[#36] Añadir reemplazo de nombres de comité en esquemas Formly (dev)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
        ### Security         Correcciones de vulnerabilidades
 -->
 ### Added
-- Añadido soporte para el idioma catalán.
+- Añadido soporte para el idioma catalán ([#23](https://github.com/herculesproject/sgi/issues/23)).
+
+### Changed
+- [ETI] Añadir reemplazo de placeholders de nombre de comité en esquemas Formly para el contexto dev ([#36](https://github.com/herculesproject/sgi/issues/36)).
 
 ## 1.0.0 (2026-02-26)
 

--- a/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/01.01.00-update-sample-data.xml
+++ b/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/01.01.00-update-sample-data.xml
@@ -61,4 +61,128 @@
       </whereParams>
     </update>
   </changeSet>
+
+  <!-- Comite M10 (CEISH) -->
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m10-ca">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M10_ca#', 'CEISH')
+        WHERE esquema LIKE '%#nombre_comite_M10_ca#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m10-es">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M10_es#', 'CEISH')
+        WHERE esquema LIKE '%#nombre_comite_M10_es#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m10-en">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M10_en#', 'CEISH')
+        WHERE esquema LIKE '%#nombre_comite_M10_en#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m10-eu">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M10_eu#', 'CEISH')
+        WHERE esquema LIKE '%#nombre_comite_M10_eu#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <!-- Comite M20 (CEEA) -->
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m20-ca">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M20_ca#', 'CEEA')
+        WHERE esquema LIKE '%#nombre_comite_M20_ca#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m20-es">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M20_es#', 'CEEA')
+        WHERE esquema LIKE '%#nombre_comite_M20_es#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m20-en">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M30_en#', 'CEEA')
+        WHERE esquema LIKE '%#nombre_comite_M20_en#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m20-eu">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M20_eu#', 'CEEA')
+        WHERE esquema LIKE '%#nombre_comite_M20_eu#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <!-- Comite M30 (CBE) -->
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m30-ca">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M30_ca#', 'CBE')
+        WHERE esquema LIKE '%#nombre_comite_M30_ca#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m30-es">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M30_es#', 'CBE')
+        WHERE esquema LIKE '%#nombre_comite_M30_es#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m30-en">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M30_en#', 'CBE')
+        WHERE esquema LIKE '%#nombre_comite_M30_en#%'
+      ]]>
+    </sql>
+  </changeSet>
+
+  <changeSet context="dev" author="master" id="01.01.00-nombre-comite-m30-eu">
+    <sql>
+      <![CDATA[
+        UPDATE ${schemaPrefix}apartado_definicion
+        SET esquema = REPLACE(esquema, '#nombre_comite_M30_eu#', 'CBE')
+        WHERE esquema LIKE '%#nombre_comite_M30_eu#%'
+      ]]>
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/m10/m10_apartado_3_5.json
+++ b/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/m10/m10_apartado_3_5.json
@@ -82,7 +82,7 @@
         "wrappers": [
           "info-div"
         ],
-        "template": "<p>Nota: Recordeu que la manipulació de teixits/sang/fluids humans requereix avaluació del #nom_comite_M30_ca#.</p><p>Les opcions marcades amb asterisc (*) requereixen l'informe previ favorable de la Comissió de Garanties abans de la seva utilització</p>",
+        "template": "<p>Nota: Recordeu que la manipulació de teixits/sang/fluids humans requereix avaluació del #nombre_comite_M30_ca#.</p><p>Les opcions marcades amb asterisc (*) requereixen l'informe previ favorable de la Comissió de Garanties abans de la seva utilització</p>",
         "hideExpression": "!model.muestrasBiologicasRadio || model.muestrasBiologicasRadio === 'no'"
       }
     ]

--- a/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/m20/m20_apartado_3_6_2.json
+++ b/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/m20/m20_apartado_3_6_2.json
@@ -33,7 +33,7 @@
         "wrappers": [
           "info-div"
         ],
-        "template": "<p>Nota: Requereix informe del #nom_comite_M30_ca#.</p>"
+        "template": "<p>Nota: Requereix informe del #nombre_comite_M30_ca#.</p>"
       },
       {
         "template": "¿Impliquen riscos per a la salut humana, animal o per al medi ambient?",

--- a/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/m20/m20_apartado_3_7_7.json
+++ b/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/m20/m20_apartado_3_7_7.json
@@ -33,7 +33,7 @@
         "wrappers": [
           "info-div"
         ],
-        "template": "<p>Si el procés d'experimentació requereix treballar amb agents biològics (AB) o organismes modificats genèticament (OMG) en un laboratori de nivell de contenció 2 o superior, cal sol·licitar l'avaluació al #nom_comite_M30_ca#.</p>"
+        "template": "<p>Si el procés d'experimentació requereix treballar amb agents biològics (AB) o organismes modificats genèticament (OMG) en un laboratori de nivell de contenció 2 o superior, cal sol·licitar l'avaluació al #nombre_comite_M30_ca#.</p>"
       },
       {
         "key": "tipoAgenteBiologico",

--- a/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/seguimiento_anual_apartado_1.json
+++ b/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/seguimiento_anual_apartado_1.json
@@ -13,7 +13,7 @@
         "wrappers": [
           "info-div"
         ],
-        "template": "<p>Ompliu aquest punt en funció del comitè al qual s'adreça el vostre informe:<ul><li>Per al #nom_comite_M10_ca# data d'inici del reclutament.</li><li>Per al #nom_comite_M20_ca# data d'inici d'ús d'animals d'experimentació.</li><li>Per al #nom_de_com u OMG, SQP, SR.</li></ul></p>"
+        "template": "<p>Ompliu aquest punt en funció del comitè al qual s'adreça el vostre informe:<ul><li>Per al #nombre_comite_M10_ca# data d'inici del reclutament.</li><li>Per al #nombre_comite_M20_ca# data d'inici d'ús d'animals d'experimentació.</li><li>Per al #nom_de_com u OMG, SQP, SR.</li></ul></p>"
       },
       {
         "key": "fechaInicio",

--- a/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/seguimiento_anual_apartado_3.json
+++ b/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/seguimiento_anual_apartado_3.json
@@ -13,7 +13,7 @@
         "wrappers": [
           "info-div"
         ],
-        "template": "<p>La descripció respecte al disseny metodològic dependrà del comitè a què es dirigeix l'informe anual.<ul><li>Per al #nom_comite_M10_ca#, descrivint la mostra actual (característiques i mida) i el desenvolupament del projecte, indicant si han sorgit problemes i com s'han resolt.</li><li>Per al #nom_ total d'animals utilitzats fins ara) i el desenvolupament del projecte, indicant si han sorgit problemes i com s'han resolt.</li><li>Per al #nom_comite_M30_ca#, el desenvolupament del projecte, indicant si han sorgit problemes i com s'han resolt."
+        "template": "<p>La descripció respecte al disseny metodològic dependrà del comitè a què es dirigeix l'informe anual.<ul><li>Per al #nombre_comite_M10_ca#, descrivint la mostra actual (característiques i mida) i el desenvolupament del projecte, indicant si han sorgit problemes i com s'han resolt.</li><li>Per al #nom_ total d'animals utilitzats fins ara) i el desenvolupament del projecte, indicant si han sorgit problemes i com s'han resolt.</li><li>Per al #nombre_comite_M30_ca#, el desenvolupament del projecte, indicant si han sorgit problemes i com s'han resolt."
       },
       {
         "template": "Descriviu breument com es va desenvolupant metodològicament el projecte i assenyaleu els problemes trobats i les seves solucions, si n'hi ha hagut."

--- a/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/seguimiento_anual_apartado_4.json
+++ b/sgi-eti-service/src/main/resources/db/changelog/changes/1.1.0/clob/ca/seguimiento_anual_apartado_4.json
@@ -13,7 +13,7 @@
         "wrappers": [
           "info-div"
         ],
-        "template": "<p>La descripció respecte als aspectes ètics específics dependrà del comitè a què s'adreça l'informe anual i recollirà el que ha passat l'any objecte de l'informe. #nom_comite_M20_ca# el desenvolupament i els problemes sorgits al voltant del reemplaçament, al refinament ia la reducció.</li><li>Per al #nom_comite_M30_ca# el desenvolupament i els problemes sorgits al voltant de la prevenció dels riscos per a la salut o per al medi ambient relacionats amb els agents biològics</> ."
+        "template": "<p>La descripció respecte als aspectes ètics específics dependrà del comitè a què s'adreça l'informe anual i recollirà el que ha passat l'any objecte de l'informe. #nombre_comite_M20_ca# el desenvolupament i els problemes sorgits al voltant del reemplaçament, al refinament ia la reducció.</li><li>Per al #nombre_comite_M30_ca# el desenvolupament i els problemes sorgits al voltant de la prevenció dels riscos per a la salut o per al medi ambient relacionats amb els agents biològics</> ."
       },
       {
         "template": "Descriviu breument com es van desenvolupant els aspectes ètics del projecte i assenyaleu els problemes trobats i les seves solucions, si n'hi ha hagut."


### PR DESCRIPTION
Se añaden changesets de Liquibase que sustituyen los placeholders de nombre de comité en el campo esquema de apartado_definicion.

Los cambios se aplican en el contexto dev para los formularios M10, M20 y M30 (y sus formularios relacionados), utilizando los nombres de comité por defecto del contexto dev (CEISH, CEEA y CBE).