### PR TITLE
[#51] [CSP] Líneas investigación - Añadir descripción

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Añadida documentación para las apis de integración: SGP, SGEMP, SGO, SGE y SGDOC. ([#47](https://github.com/herculesproject/sgi/issues/47)).
 - [CSP] Añadida tabla maestra de tipos de grupo de investigación (`tipo_grupo`) en sustitución del enum anterior (EMERGENTE, CONSOLIDADO, PRECOMPETITIVO, ALTO_RENDIMIENTO), con soporte i18n y personalizable por instalación (configurable en *CSP > Configuración > Tipos de grupo*) ([#45](https://github.com/herculesproject/sgi/issues/45)).
 - [CSP] Añadidos los campos acrónimo, dirección, email e imagen en los datos generales del grupo de investigación. La relación de aspecto recomendada y el tamaño máximo de la imagen son configurables en *CSP > Configuración* ([#37](https://github.com/herculesproject/sgi/issues/37)).
+- [CSP] Añadido el campo descripción con soporte i18n en las líneas de investigación ([#51](https://github.com/herculesproject/sgi/issues/51)).
 - [WEB] Añadido soporte en el componente compartido de subida de ficheros para la descarga del fichero asociado, tooltips configurables y validación de tamaño máximo ([#37](https://github.com/herculesproject/sgi/issues/37)).
 
 ### Changed

--- a/docs/upgrade/1.1.0-SNAPSHOT.md
+++ b/docs/upgrade/1.1.0-SNAPSHOT.md
@@ -55,9 +55,7 @@ Lista de servicios que incluyen cambios en el modelo de datos y/o actualizacione
 
 | Servicio | Path cambios | Descripción |
 |---|---|---|
-| sgi-csp-service | [sgi-csp-service/src/main/resources/db/changelog/changes/1.1.0](../../sgi-csp-service/src/main/resources/db/changelog/changes/1.1.0) | - **[#45](https://github.com/herculesproject/sgi/issues/45):** Nuevas tablas `tipo_grupo`, `tipo_grupo_nombre` y `tipo_grupo_descripcion` (tabla maestra con i18n). En `grupo_tipo` se añade FK `tipo_grupo_id` (`NOT NULL`, con migración automática desde la columna `tipo`) y se elimina la columna `tipo`.<br>- **[#37](https://github.com/herculesproject/sgi/issues/37):** Nuevas columnas en `grupo` (`acronimo`, `direccion`, `email`, `imagen_ref`) y en `configuracion` (`grupo_imagen_aspecto`, `grupo_imagen_tamanio_maximo`). |
-
-
+| sgi-csp-service | [sgi-csp-service/src/main/resources/db/changelog/changes/1.1.0](../../sgi-csp-service/src/main/resources/db/changelog/changes/1.1.0) | - **[#45](https://github.com/herculesproject/sgi/issues/45):** Nuevas tablas `tipo_grupo`, `tipo_grupo_nombre` y `tipo_grupo_descripcion` (tabla maestra con i18n). En `grupo_tipo` se añade FK `tipo_grupo_id` (`NOT NULL`, con migración automática desde la columna `tipo`) y se elimina la columna `tipo`.<br>- **[#37](https://github.com/herculesproject/sgi/issues/37):** Nuevas columnas en `grupo` (`acronimo`, `direccion`, `email`, `imagen_ref`) y en `configuracion` (`grupo_imagen_aspecto`, `grupo_imagen_tamanio_maximo`).<br>- **[#51](https://github.com/herculesproject/sgi/issues/51):** Nueva tabla `linea_investigacion_descripcion` (tabla de i18n con, `value_` `VARCHAR(3000)`) asociada a `linea_investigacion`. |
 ## Procedimiento de actualización
 
 1. Aplicar en los ficheros `values.yaml` de cada entorno los cambios de configuración descritos en la sección [Configuración](#configuración).

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/dto/LineaInvestigacionInput.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/dto/LineaInvestigacionInput.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import javax.validation.constraints.NotEmpty;
 
-import org.crue.hercules.sgi.csp.model.LineaInvestigacionNombre;
+import org.crue.hercules.sgi.framework.i18n.I18nFieldValueDto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +19,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class LineaInvestigacionInput implements Serializable {
+
   @NotEmpty
-  private List<LineaInvestigacionNombre> nombre;
+  private List<I18nFieldValueDto> nombre;
+
+  private List<I18nFieldValueDto> descripcion;
 
 }

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/dto/LineaInvestigacionOutput.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/dto/LineaInvestigacionOutput.java
@@ -3,6 +3,7 @@ package org.crue.hercules.sgi.csp.dto;
 import java.io.Serializable;
 import java.util.Collection;
 
+import org.crue.hercules.sgi.csp.model.LineaInvestigacionDescripcion;
 import org.crue.hercules.sgi.csp.model.LineaInvestigacionNombre;
 
 import lombok.AllArgsConstructor;
@@ -19,5 +20,6 @@ import lombok.NoArgsConstructor;
 public class LineaInvestigacionOutput implements Serializable {
   private Long id;
   private Collection<LineaInvestigacionNombre> nombre;
+  private Collection<LineaInvestigacionDescripcion> descripcion;
   private Boolean activo;
 }

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/dto/TipoGrupoInput.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/dto/TipoGrupoInput.java
@@ -5,8 +5,7 @@ import java.util.List;
 
 import javax.validation.constraints.NotEmpty;
 
-import org.crue.hercules.sgi.csp.model.TipoGrupoDescripcion;
-import org.crue.hercules.sgi.csp.model.TipoGrupoNombre;
+import org.crue.hercules.sgi.framework.i18n.I18nFieldValueDto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,8 +21,8 @@ import lombok.NoArgsConstructor;
 public class TipoGrupoInput implements Serializable {
 
   @NotEmpty
-  private List<TipoGrupoNombre> nombre;
+  private List<I18nFieldValueDto> nombre;
 
-  private List<TipoGrupoDescripcion> descripcion;
+  private List<I18nFieldValueDto> descripcion;
 
 }

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/model/LineaInvestigacion.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/model/LineaInvestigacion.java
@@ -56,4 +56,11 @@ public class LineaInvestigacion extends BaseActivableEntity {
   @Builder.Default
   private Set<LineaInvestigacionNombre> nombre = new HashSet<>();
 
+  /** Descripcion. */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "linea_investigacion_descripcion", joinColumns = @JoinColumn(name = "linea_investigacion_id"))
+  @Valid
+  @Builder.Default
+  private Set<LineaInvestigacionDescripcion> descripcion = new HashSet<>();
+
 }

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/model/LineaInvestigacionDescripcion.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/model/LineaInvestigacionDescripcion.java
@@ -1,0 +1,44 @@
+package org.crue.hercules.sgi.csp.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.crue.hercules.sgi.framework.i18n.I18nFieldValue;
+import org.crue.hercules.sgi.framework.i18n.Language;
+import org.crue.hercules.sgi.framework.persistence.LanguageConverter;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Línea investigación -> Descripcion
+ */
+@Data
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class LineaInvestigacionDescripcion implements Serializable, I18nFieldValue {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Language. */
+  @Column(name = "lang", nullable = false, length = 2)
+  @Convert(converter = LanguageConverter.class)
+  @NotNull
+  private Language lang;
+
+  /** Descripcion */
+  @Column(name = "value_", length = 3000, nullable = false)
+  @NotBlank
+  @Size(max = 3000)
+  private String value;
+}

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/LineaInvestigacionService.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/LineaInvestigacionService.java
@@ -13,6 +13,7 @@ import org.crue.hercules.sgi.csp.model.BaseEntity;
 import org.crue.hercules.sgi.csp.model.LineaInvestigacion;
 import org.crue.hercules.sgi.csp.repository.LineaInvestigacionRepository;
 import org.crue.hercules.sgi.csp.repository.specification.LineaInvestigacionSpecifications;
+import org.crue.hercules.sgi.csp.util.AssertHelper;
 import org.crue.hercules.sgi.framework.problem.message.ProblemMessage;
 import org.crue.hercules.sgi.framework.rsql.SgiRSQLJPASupport;
 import org.crue.hercules.sgi.framework.spring.context.support.ApplicationContextSupport;
@@ -54,11 +55,7 @@ public class LineaInvestigacionService {
   public LineaInvestigacion create(@Valid LineaInvestigacion lineaInvestigacion) {
     log.debug("create(LineaInvestigacion lineaInvestigacion) - start");
 
-    Assert.isNull(lineaInvestigacion.getId(),
-        // Defer message resolution untill is needed
-        () -> ProblemMessage.builder().key(Assert.class, "isNull")
-            .parameter("field", ApplicationContextSupport.getMessage("id"))
-            .parameter("entity", ApplicationContextSupport.getMessage(LineaInvestigacion.class)).build());
+    AssertHelper.idIsNull(lineaInvestigacion.getId(), LineaInvestigacion.class);
 
     lineaInvestigacion.setActivo(Boolean.TRUE);
     LineaInvestigacion returnValue = repository.save(lineaInvestigacion);
@@ -80,14 +77,11 @@ public class LineaInvestigacionService {
   public LineaInvestigacion update(@Valid LineaInvestigacion lineaInvestigacion) {
     log.debug("update(LineaInvestigacion lineaInvestigacion) - start");
 
-    Assert.notNull(lineaInvestigacion.getId(),
-        // Defer message resolution untill is needed
-        () -> ProblemMessage.builder().key(Assert.class, "notNull")
-            .parameter("field", ApplicationContextSupport.getMessage("id"))
-            .parameter("entity", ApplicationContextSupport.getMessage(LineaInvestigacion.class)).build());
+    AssertHelper.idNotNull(lineaInvestigacion.getId(), LineaInvestigacion.class);
 
-    return repository.findById(lineaInvestigacion.getId()).map((data) -> {
+    return repository.findById(lineaInvestigacion.getId()).map(data -> {
       data.setNombre(lineaInvestigacion.getNombre());
+      data.setDescripcion(lineaInvestigacion.getDescripcion());
 
       LineaInvestigacion returnValue = repository.save(data);
       log.debug("update(LineaInvestigacion lineaInvestigacion) - end");

--- a/sgi-csp-service/src/main/resources/db/changelog/changes/1.1.0/1.1.0-update-initial-database.xml
+++ b/sgi-csp-service/src/main/resources/db/changelog/changes/1.1.0/1.1.0-update-initial-database.xml
@@ -106,4 +106,27 @@
     </addColumn>
   </changeSet>
 
+  <changeSet author="master" id="1.1.0-8">
+    <createTable tableName="linea_investigacion_descripcion">
+      <column name="linea_investigacion_id" type="BIGINT">
+        <constraints nullable="false" />
+      </column>
+      <column name="lang" type="VARCHAR(2)">
+        <constraints nullable="false" />
+      </column>
+      <column name="value_" type="VARCHAR(3000)">
+        <constraints nullable="false" />
+      </column>
+    </createTable>
+
+    <addPrimaryKey tableName="linea_investigacion_descripcion"
+      columnNames="linea_investigacion_id, lang" />
+
+    <addForeignKeyConstraint baseColumnNames="linea_investigacion_id"
+      baseTableName="linea_investigacion_descripcion"
+      constraintName="FK_LINEAINVESTIGACIONDESCRIPCION_LINEAINVESTIGACION" deferrable="false"
+      initiallyDeferred="false"
+      referencedColumnNames="id" referencedTableName="linea_investigacion" validate="true" />
+  </changeSet>
+
 </databaseChangeLog>

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/LineaInvestigacionIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/LineaInvestigacionIT.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.crue.hercules.sgi.csp.dto.LineaInvestigacionOutput;
 import org.crue.hercules.sgi.csp.model.LineaInvestigacion;
+import org.crue.hercules.sgi.csp.model.LineaInvestigacionDescripcion;
 import org.crue.hercules.sgi.csp.model.LineaInvestigacionNombre;
 import org.crue.hercules.sgi.framework.i18n.I18nHelper;
 import org.crue.hercules.sgi.framework.i18n.Language;
@@ -42,8 +43,7 @@ class LineaInvestigacionIT extends BaseIT {
     headers.set("Authorization", String.format("bearer %s", tokenBuilder.buildToken("user", "CSP-LIN-V", "CSP-LIN-C",
         "CSP-LIN-E", "CSP-LIN-B", "CSP-LIN-R", "AUTH")));
 
-    HttpEntity<LineaInvestigacion> request = new HttpEntity<>(entity, headers);
-    return request;
+    return new HttpEntity<>(entity, headers);
   }
 
   @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:cleanup.sql")
@@ -53,8 +53,11 @@ class LineaInvestigacionIT extends BaseIT {
     // given: new LineaInvestigacion
     Set<LineaInvestigacionNombre> nombreLineaInvestigacion = new HashSet<>();
     nombreLineaInvestigacion.add(new LineaInvestigacionNombre(Language.ES, "nombre-1"));
+    Set<LineaInvestigacionDescripcion> descripcionLineaInvestigacion = new HashSet<>();
+    descripcionLineaInvestigacion.add(new LineaInvestigacionDescripcion(Language.ES, "descripcion-1"));
     LineaInvestigacion data = LineaInvestigacion.builder()
         .nombre(nombreLineaInvestigacion)
+        .descripcion(descripcionLineaInvestigacion)
         .activo(Boolean.TRUE)
         .build();
 
@@ -67,6 +70,7 @@ class LineaInvestigacionIT extends BaseIT {
     LineaInvestigacion responseData = response.getBody();
     Assertions.assertThat(responseData.getId()).as("getId()").isNotNull();
     Assertions.assertThat(responseData.getNombre()).as("getNombre()").isEqualTo(data.getNombre());
+    Assertions.assertThat(responseData.getDescripcion()).as("getDescripcion()").isEqualTo(data.getDescripcion());
     Assertions.assertThat(responseData.getActivo()).as("getActivo()").isEqualTo(data.getActivo());
   }
 
@@ -82,9 +86,12 @@ class LineaInvestigacionIT extends BaseIT {
     // given: existing LineaInvestigacion to be updated
     Set<LineaInvestigacionNombre> nombreLineaInvestigacion = new HashSet<>();
     nombreLineaInvestigacion.add(new LineaInvestigacionNombre(Language.ES, "nombre-updated"));
+    Set<LineaInvestigacionDescripcion> descripcionLineaInvestigacion = new HashSet<>();
+    descripcionLineaInvestigacion.add(new LineaInvestigacionDescripcion(Language.ES, "descripcion-updated"));
     LineaInvestigacion data = LineaInvestigacion.builder()
         .id(2L)
         .nombre(nombreLineaInvestigacion)
+        .descripcion(descripcionLineaInvestigacion)
         .activo(Boolean.TRUE)
         .build();
 
@@ -97,6 +104,7 @@ class LineaInvestigacionIT extends BaseIT {
     LineaInvestigacion responseData = response.getBody();
     Assertions.assertThat(responseData.getId()).as("getId()").isEqualTo(data.getId());
     Assertions.assertThat(responseData.getNombre()).as("getNombre()").isEqualTo(data.getNombre());
+    Assertions.assertThat(responseData.getDescripcion()).as("getDescripcion()").isEqualTo(data.getDescripcion());
     Assertions.assertThat(responseData.getActivo()).as("getActivo()").isEqualTo(data.getActivo());
   }
 
@@ -163,6 +171,8 @@ class LineaInvestigacionIT extends BaseIT {
     Assertions.assertThat(responseData.getId()).as("getId()").isEqualTo(id);
     Assertions.assertThat(I18nHelper.getValueForLanguage(responseData.getNombre(), Language.ES))
         .as("getNombre()").isEqualTo("Psicología Laboral u Organizacional");
+    Assertions.assertThat(I18nHelper.getValueForLanguage(responseData.getDescripcion(), Language.ES))
+        .as("getDescripcion()").isEqualTo("Descripción de la línea de investigación 1");
     Assertions.assertThat(responseData.getActivo()).as("getActivo()").isEqualTo(Boolean.FALSE);
   }
 

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/TipoGrupoIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/TipoGrupoIT.java
@@ -8,7 +8,7 @@ import org.assertj.core.api.Assertions;
 import org.crue.hercules.sgi.csp.controller.TipoGrupoController;
 import org.crue.hercules.sgi.csp.dto.TipoGrupoInput;
 import org.crue.hercules.sgi.csp.dto.TipoGrupoOutput;
-import org.crue.hercules.sgi.csp.model.TipoGrupoNombre;
+import org.crue.hercules.sgi.framework.i18n.I18nFieldValueDto;
 import org.crue.hercules.sgi.framework.i18n.I18nHelper;
 import org.crue.hercules.sgi.framework.i18n.Language;
 import org.junit.jupiter.api.Test;
@@ -48,7 +48,7 @@ class TipoGrupoIT extends BaseIT {
 
   private TipoGrupoInput buildMockTipoGrupo() {
     return TipoGrupoInput.builder()
-        .nombre(List.of(new TipoGrupoNombre(Language.ES, "Nuevo tipo")))
+        .nombre(List.of(new I18nFieldValueDto(Language.ES, "Nuevo tipo")))
         .build();
   }
 
@@ -85,7 +85,7 @@ class TipoGrupoIT extends BaseIT {
   void update_ReturnsTipoGrupo() throws Exception {
     Long id = 1L;
     TipoGrupoInput toUpdate = TipoGrupoInput.builder()
-        .nombre(List.of(new TipoGrupoNombre(Language.ES, "Emergente actualizado")))
+        .nombre(List.of(new I18nFieldValueDto(Language.ES, "Emergente actualizado")))
         .build();
     String roles = "CSP-TGIN-E";
 
@@ -148,8 +148,7 @@ class TipoGrupoIT extends BaseIT {
       "classpath:scripts/tipo-grupo.sql"
       // @formatter:on
   })
-  @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
-      statements = "UPDATE test.tipo_grupo SET activo = false WHERE id = 1")
+  @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, statements = "UPDATE test.tipo_grupo SET activo = false WHERE id = 1")
   @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:cleanup.sql")
   @Test
   void reactivar_ReturnsTipoGrupo() throws Exception {

--- a/sgi-csp-service/src/test/resources/cleanup.sql
+++ b/sgi-csp-service/src/test/resources/cleanup.sql
@@ -242,6 +242,7 @@ DELETE FROM test.tipo_regimen_concurrencia;
 DELETE FROM test.concepto_gasto_nombre;
 DELETE FROM test.concepto_gasto_descripcion;
 DELETE FROM test.concepto_gasto;
+DELETE FROM test.linea_investigacion_descripcion;
 DELETE FROM test.linea_investigacion_nombre;
 DELETE FROM test.linea_investigacion;
 DELETE FROM test.tipo_facturacion_nombre;

--- a/sgi-csp-service/src/test/resources/scripts/linea_investigacion.sql
+++ b/sgi-csp-service/src/test/resources/scripts/linea_investigacion.sql
@@ -9,3 +9,9 @@ INSERT INTO test.linea_investigacion_nombre (linea_investigacion_id, lang, value
 (1, 'es', 'Psicología Laboral u Organizacional'),
 (2, 'es', 'Psicología Clínica de la Salud'),
 (3, 'es', 'Psicología general');
+
+-- LINEA_INVESTIGACION_DESCRIPCION
+INSERT INTO test.linea_investigacion_descripcion (linea_investigacion_id, lang, value_) VALUES
+(1, 'es', 'Descripción de la línea de investigación 1'),
+(2, 'es', 'Descripción de la línea de investigación 2'),
+(3, 'es', 'Descripción de la línea de investigación 3');

--- a/sgi-webapp/src/app/core/models/csp/linea-investigacion.ts
+++ b/sgi-webapp/src/app/core/models/csp/linea-investigacion.ts
@@ -3,5 +3,6 @@ import { I18nFieldValue } from "@core/i18n/i18n-field";
 export interface ILineaInvestigacion {
   id: number;
   nombre: I18nFieldValue[];
+  descripcion: I18nFieldValue[];
   activo: boolean;
 }

--- a/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-request.converter.ts
+++ b/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-request.converter.ts
@@ -11,6 +11,7 @@ class LineaInvestigacionRequestConverter extends SgiBaseConverter<ILineaInvestig
     return {
       id: undefined,
       nombre: value.nombre ? I18N_FIELD_REQUEST_CONVERTER.toTargetArray(value.nombre) : [],
+      descripcion: value.descripcion ? I18N_FIELD_REQUEST_CONVERTER.toTargetArray(value.descripcion) : [],
       activo: true
     };
   }
@@ -20,6 +21,7 @@ class LineaInvestigacionRequestConverter extends SgiBaseConverter<ILineaInvestig
     }
     return {
       nombre: value.nombre ? I18N_FIELD_REQUEST_CONVERTER.fromTargetArray(value.nombre) : [],
+      descripcion: value.descripcion ? I18N_FIELD_REQUEST_CONVERTER.fromTargetArray(value.descripcion) : [],
     };
   }
 }

--- a/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-request.ts
+++ b/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-request.ts
@@ -1,5 +1,6 @@
-import { I18nFieldValueRequest } from "@core/i18n/i18n-field-request";
+import { I18nFieldValueRequest } from '@core/i18n/i18n-field-request';
 
 export interface ILineaInvestigacionRequest {
   nombre: I18nFieldValueRequest[];
+  descripcion: I18nFieldValueRequest[];
 }

--- a/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-response.converter.ts
+++ b/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-response.converter.ts
@@ -11,6 +11,7 @@ class LineaInvestigacionResponseConverter extends SgiBaseConverter<ILineaInvesti
     return {
       id: value.id,
       nombre: value.nombre ? I18N_FIELD_RESPONSE_CONVERTER.toTargetArray(value.nombre) : [],
+      descripcion: value.descripcion ? I18N_FIELD_RESPONSE_CONVERTER.toTargetArray(value.descripcion) : [],
       activo: value.activo
     };
   }
@@ -21,6 +22,7 @@ class LineaInvestigacionResponseConverter extends SgiBaseConverter<ILineaInvesti
     return {
       id: value.id,
       nombre: value.nombre ? I18N_FIELD_RESPONSE_CONVERTER.fromTargetArray(value.nombre) : [],
+      descripcion: value.descripcion ? I18N_FIELD_RESPONSE_CONVERTER.fromTargetArray(value.descripcion) : [],
       activo: value.activo
     };
   }

--- a/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-response.ts
+++ b/sgi-webapp/src/app/core/services/csp/linea-investigacion/linea-investigacion-response.ts
@@ -1,7 +1,8 @@
-import { I18nFieldValueResponse } from "@core/i18n/i18n-field-response";
+import { I18nFieldValueResponse } from '@core/i18n/i18n-field-response';
 
 export interface ILineaInvestigacionResponse {
   id: number;
   nombre: I18nFieldValueResponse[];
+  descripcion: I18nFieldValueResponse[];
   activo: boolean;
 }

--- a/sgi-webapp/src/app/module/csp/linea-investigacion/linea-investigacion-listado/linea-investigacion-listado.component.html
+++ b/sgi-webapp/src/app/module/csp/linea-investigacion/linea-investigacion-listado/linea-investigacion-listado.component.html
@@ -30,10 +30,10 @@
 
     <div class="buttons-final">
       <div class="col filter-button">
-        <button color="primary" aria-label="Center Align" mat-raised-button (click)="onSearch()">
+        <button color="primary" mat-raised-button (click)="onSearch()">
           <mat-icon>search</mat-icon> {{'btn.search'| translate}}
         </button>
-        <button color="warn" aria-label="Center Align" (click)="onClearFilters()" mat-button>{{'btn.clean'|
+        <button color="warn" (click)="onClearFilters()" mat-button>{{'btn.clean'|
           translate}}
         </button>
       </div>
@@ -96,7 +96,7 @@
   </div>
   <ng-container *sgiHasAuthority="'CSP-LIN-C'">
     <div class="separation-button">
-      <button color="three" aria-label="Center Align" mat-raised-button (click)="openModal()">
+      <button color="three" mat-raised-button (click)="openModal()">
         <mat-icon color="accent">add_circle</mat-icon>
         {{ 'btn.add.entity' | translate:msgParamEntity }}
       </button>

--- a/sgi-webapp/src/app/module/csp/linea-investigacion/linea-investigacion-modal/linea-investigacion-modal.component.html
+++ b/sgi-webapp/src/app/module/csp/linea-investigacion/linea-investigacion-modal/linea-investigacion-modal.component.html
@@ -1,7 +1,7 @@
 <sgi-action-dialog [title]="title" class="modal-lineas-investigacion">
   <form [formGroup]="formGroup">
     <!-- Nombre -->
-    <div fxLayout="row" fxFlex="600px" style="margin-bottom: 100px">
+    <div fxLayout="row">
       <mat-form-field>
         <mat-label>{{'csp.linea-investigacion.nombre' | translate}}</mat-label>
         <sgi-input-linea-investigacion formControlName="nombre"
@@ -11,6 +11,18 @@
         </mat-error>
         <mat-error *ngIf="formGroup.controls.nombre.errors?.maxlength">
           {{'error.maxlength.entity' | translate:msgParamNombreEntity}}
+        </mat-error>
+      </mat-form-field>
+    </div>
+    <!-- Descripción -->
+    <div fxLayout="row">
+      <mat-form-field>
+        <mat-label>{{'csp.linea-investigacion.descripcion' | translate}}</mat-label>
+        <sgi-i18n-textarea formControlName="descripcion"
+          placeholder="{{'linea-investigacion.descripcion' | translate}}">
+        </sgi-i18n-textarea>
+        <mat-error *ngIf="formGroup.controls.descripcion.errors?.maxlength">
+          {{'error.maxlength.entity' | translate:msgParamDescripcionEntity}}
         </mat-error>
       </mat-form-field>
     </div>

--- a/sgi-webapp/src/app/module/csp/linea-investigacion/linea-investigacion-modal/linea-investigacion-modal.component.ts
+++ b/sgi-webapp/src/app/module/csp/linea-investigacion/linea-investigacion-modal/linea-investigacion-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { marker } from '@biesbjerg/ngx-translate-extract-marker';
 import { DialogActionComponent } from '@core/component/dialog-action.component';
 import { MSG_PARAMS } from '@core/i18n';
@@ -12,6 +12,7 @@ import { Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 const LINEA_INVESTIGACION_KEY = marker('csp.linea-investigacion');
+const LINEA_INVESTIGACION_DESCRIPCION_KEY = marker('csp.linea-investigacion.descripcion');
 const LINEA_INVESTIGACION_NOMBRE_KEY = marker('csp.linea-investigacion.nombre');
 const TITLE_NEW_ENTITY = marker('title.new.entity');
 
@@ -23,6 +24,7 @@ export class LineaInvestigacionModalComponent extends DialogActionComponent<ILin
 
   private readonly lineaInvestigacion: ILineaInvestigacion;
   title: string;
+  msgParamDescripcionEntity = {};
   msgParamNombreEntity = {};
 
   constructor(
@@ -42,6 +44,7 @@ export class LineaInvestigacionModalComponent extends DialogActionComponent<ILin
 
   ngOnInit(): void {
     super.ngOnInit();
+    this.matDialogRef.updateSize('30vw');
     this.setupI18N();
   }
 
@@ -50,6 +53,15 @@ export class LineaInvestigacionModalComponent extends DialogActionComponent<ILin
       LINEA_INVESTIGACION_NOMBRE_KEY,
       MSG_PARAMS.CARDINALIRY.SINGULAR
     ).subscribe((value) => this.msgParamNombreEntity = { entity: value, ...MSG_PARAMS.GENDER.MALE, ...MSG_PARAMS.CARDINALIRY.SINGULAR });
+
+    this.translate.get(
+      LINEA_INVESTIGACION_DESCRIPCION_KEY,
+      MSG_PARAMS.CARDINALIRY.SINGULAR
+    ).subscribe((value) => this.msgParamDescripcionEntity = {
+      entity: value,
+      ...MSG_PARAMS.GENDER.FEMALE,
+      ...MSG_PARAMS.CARDINALIRY.SINGULAR
+    });
 
     if (this.isEdit()) {
       this.translate.get(
@@ -73,12 +85,14 @@ export class LineaInvestigacionModalComponent extends DialogActionComponent<ILin
 
   protected getValue(): ILineaInvestigacion {
     this.lineaInvestigacion.nombre = this.formGroup.controls.nombre.value;
+    this.lineaInvestigacion.descripcion = this.formGroup.controls.descripcion.value;
     return this.lineaInvestigacion;
   }
 
   protected buildFormGroup(): FormGroup {
     const formGroup = new FormGroup({
       nombre: new FormControl(this.lineaInvestigacion?.nombre ?? [], [I18nValidators.maxLength(1000), I18nValidators.required]),
+      descripcion: new FormControl(this.lineaInvestigacion?.descripcion ?? [], [I18nValidators.maxLength(3000)]),
     });
     return formGroup;
   }

--- a/sgi-webapp/src/assets/i18n/ca.json
+++ b/sgi-webapp/src/assets/i18n/ca.json
@@ -881,6 +881,7 @@
   "csp.identificador-justificacion.identificador-justificacion.identificador-vinculado-requerimiento": "Hi ha un requeriment associat a aquest ID de justificació que voleu modificar/eliminar voleu continuar?",
   "csp.identificador-justificacion.title": "Identificador de justificació",
   "csp.linea-investigacion": "Línia{count,plural,=0{} one{} other{s}} d'investigació",
+  "csp.linea-investigacion.descripcion": "Descripció",
   "csp.linea-investigacion.nombre": "Nom",
   "csp.miembro-equipo-proyecto.fecha-fin": "Data Fi",
   "csp.miembro-equipo-proyecto.fecha-inicio": "Data Inici",

--- a/sgi-webapp/src/assets/i18n/en.json
+++ b/sgi-webapp/src/assets/i18n/en.json
@@ -881,6 +881,7 @@
   "csp.identificador-justificacion.identificador-justificacion.identificador-vinculado-requerimiento": "There is a requirement associated with this justification ID that you are going to modify/delete. Do you wish to continue?",
   "csp.identificador-justificacion.title": "Justification identifier",
   "csp.linea-investigacion": "Research Line{count,plural,=0{} one{} other{s}}",
+  "csp.linea-investigacion.descripcion": "Description",
   "csp.linea-investigacion.nombre": "Name",
   "csp.miembro-equipo-proyecto.fecha-fin": "End Date",
   "csp.miembro-equipo-proyecto.fecha-inicio": "Start Date",

--- a/sgi-webapp/src/assets/i18n/es.json
+++ b/sgi-webapp/src/assets/i18n/es.json
@@ -890,6 +890,7 @@
   "csp.identificador-justificacion.identificador-justificacion.identificador-vinculado-requerimiento": "Existe un requerimiento asociado a este ID de justificación que va a modificar/eliminar ¿desea continuar?",
   "csp.identificador-justificacion.title": "Identificador de justificación",
   "csp.linea-investigacion": "Línea{count,plural,=0{} one{} other{s}} de investigación",
+  "csp.linea-investigacion.descripcion": "Descripción",
   "csp.linea-investigacion.nombre": "Nombre",
   "csp.miembro-equipo-proyecto.fecha-fin": "Fecha Fin",
   "csp.miembro-equipo-proyecto.fecha-inicio": "Fecha Inicio",

--- a/sgi-webapp/src/assets/i18n/eu.json
+++ b/sgi-webapp/src/assets/i18n/eu.json
@@ -881,6 +881,7 @@
   "csp.identificador-justificacion.identificador-justificacion.identificador-vinculado-requerimiento": "Aldatu/ezabatu nahi duzun justifikazio IDari lotutako errekerimendu bat dago. Jarraitu nahi duzu?",
   "csp.identificador-justificacion.title": "Justifikazio identifikatzailea",
   "csp.linea-investigacion": "Ikerketa lerroa{count,plural,=0{} one{} other{k}} ",
+  "csp.linea-investigacion.descripcion": "Deskribapena",
   "csp.linea-investigacion.nombre": "Izena",
   "csp.miembro-equipo-proyecto.fecha-fin": "Amaiera data",
   "csp.miembro-equipo-proyecto.fecha-inicio": "Hasiera data",


### PR DESCRIPTION
- Nueva tabla `linea_investigacion_descripcion` (tabla de i18n con, `value_` `VARCHAR(3000)`) asociada a `linea_investigacion`.
- Actualizado el modal para crear/editar líneas de investigación  con el campo descripción