### PR TITLE
[#37] [FIX][CSP] [GIN] Ampliación de campos en datos generales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
 
 ### Fixed
 - [CSP] Se corrige error al clonar una convocatoria cuando sus periodos de justificación tienen observaciones ([#62](https://github.com/herculesproject/sgi/issues/62)).
-- [CSP]  ([#62](https://github.com/herculesproject/sgi/issues/62)).
+- [CSP] Corregido el nombre del concepto de gasto que se mostraba como `[object Object]` en el listado de códigos económicos no permitidos al añadir una partida de gasto en el presupuesto del proyecto ([#74](https://github.com/herculesproject/sgi/issues/74)).
+
 
 ### Changed
 - [CSP] Reordenados los campos de la pantalla de datos generales del grupo de investigación ([#37](https://github.com/herculesproject/sgi/issues/37)).

--- a/sgi-webapp/src/app/module/csp/grupo/grupo-formulario/grupo-datos-generales/grupo-datos-generales.component.html
+++ b/sgi-webapp/src/app/module/csp/grupo/grupo-formulario/grupo-datos-generales/grupo-datos-generales.component.html
@@ -28,18 +28,9 @@
             {{'error.maxlength.entity' | translate:msgParamAcronimoEntity}}
           </mat-error>
         </mat-form-field>
-      </div>
-
-      <div fxFlex fxLayout="row" fxLayoutGap="10px">
-        <!-- Solicitud -->
-        <mat-form-field *ngIf="formGroup.controls.solicitud?.value">
-          <mat-label>{{'csp.grupo.solicitud' | translate}}</mat-label>
-          <input matInput type="text" placeholder="{{'csp.grupo.solicitud' | translate}}" formControlName="solicitud"
-            [readonly]="true">
-        </mat-form-field>
 
         <!-- Codigo -->
-        <mat-form-field>
+        <mat-form-field fxFlex="0 1 calc((100% - (10px * 2)) / 3)">
           <mat-label>{{'csp.grupo.codigo' | translate}}</mat-label>
           <input matInput type="text" placeholder="{{'csp.grupo.codigo' | translate}}" formControlName="codigo"
             required>
@@ -49,6 +40,13 @@
           <mat-error *ngIf="formGroup.controls.codigo.errors?.duplicated">
             {{ 'error.csp.grupo.codigo.duplicated' | translate }}
           </mat-error>
+        </mat-form-field>
+
+        <!-- Solicitud -->
+        <mat-form-field *ngIf="formGroup.controls.solicitud?.value" fxFlex="0 1 calc((100% - (10px * 2)) / 3)">
+          <mat-label>{{'csp.grupo.solicitud' | translate}}</mat-label>
+          <input matInput type="text" placeholder="{{'csp.grupo.solicitud' | translate}}" formControlName="solicitud"
+            [readonly]="true">
         </mat-form-field>
       </div>
 

--- a/sgi-webapp/src/app/module/csp/grupo/grupo-formulario/grupo-datos-generales/grupo-datos-generales.component.html
+++ b/sgi-webapp/src/app/module/csp/grupo/grupo-formulario/grupo-datos-generales/grupo-datos-generales.component.html
@@ -215,11 +215,9 @@
             {{'error.email.incorrect.format' | translate:msgParamEmailEntity}}
           </mat-error>
         </mat-form-field>
-      </div>
 
-      <div fxFlex fxLayout="row" fxLayoutGap="10px">
         <!-- Dirección -->
-        <mat-form-field>
+        <mat-form-field fxFlex="0 1 calc((100% - (10px * 2)) / 3 * 2 + 10px)">
           <mat-label>{{'csp.grupo.direccion' | translate}}</mat-label>
           <input matInput type="text" placeholder="{{'csp.grupo.direccion' | translate}}" formControlName="direccion">
           <mat-error *ngIf="formGroup.controls.direccion.errors?.maxlength">
@@ -453,11 +451,9 @@
             {{'error.email.incorrect.format' | translate:msgParamEmailEntity}}
           </mat-error>
         </mat-form-field>
-      </div>
 
-      <div fxFlex fxLayout="row" fxLayoutGap="10px">
         <!-- Dirección -->
-        <mat-form-field fxFlex="0 1 calc((100% - (10px * 2)) / 3)">
+        <mat-form-field fxFlex="0 1 calc((100% - (10px * 2)) / 3 * 2 + 10px)">
           <mat-label>{{'csp.grupo.direccion' | translate}}</mat-label>
           <input matInput type="text" placeholder="{{'csp.grupo.direccion' | translate}}" formControlName="direccion">
           <mat-error *ngIf="formGroup.controls.direccion.errors?.maxlength">

--- a/sgi-webapp/src/app/shared/file-upload/file-upload.component.ts
+++ b/sgi-webapp/src/app/shared/file-upload/file-upload.component.ts
@@ -1,18 +1,12 @@
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import {
-  BACKSPACE,
-  DELETE,
-  ENTER,
-  hasModifierKey,
-  SPACE,
-} from '@angular/cdk/keycodes';
+import { hasModifierKey } from '@angular/cdk/keycodes';
 import { HttpEventType } from '@angular/common/http';
 import {
   Attribute, ChangeDetectionStrategy, ChangeDetectorRef, Component,
   DoCheck, ElementRef, EventEmitter, Inject, Input, OnDestroy, OnInit, Optional, Output, Self, ViewChild
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
-import { MAT_FORM_FIELD, MatFormField, MatFormFieldControl } from '@angular/material/form-field';
+import { MatFormField, MatFormFieldControl, MAT_FORM_FIELD } from '@angular/material/form-field';
 import { IDocumento } from '@core/models/sgdoc/documento';
 import { DocumentoService, triggerDownloadToUser } from '@core/services/sgdoc/documento.service';
 import { Observable, of, Subject, throwError } from 'rxjs';
@@ -35,9 +29,9 @@ export interface UploadEvent {
   changeDetection: ChangeDetectionStrategy.OnPush,
   // tslint:disable-next-line: no-host-metadata-property
   host: {
-    'role': 'search',
+    role: 'search',
     'aria-autocomplete': 'none',
-    'class': 'mat-select',
+    class: 'mat-select',
     '[attr.id]': 'id',
     '[attr.tabindex]': 'tabIndex',
     '[attr.aria-label]': 'ariaLabel || null',
@@ -185,7 +179,11 @@ export class SgiFileUploadComponent implements
   @Output() readonly uploadStart: Observable<void> = this.uploadEventChange.pipe(filter(e => e.status === 'start'), map(() => { }));
   @Output() readonly uploadEnd: Observable<void> = this.uploadEventChange.pipe(filter(e => e.status === 'end'), map(() => { }));
   @Output() readonly uploadError: Observable<void> = this.uploadEventChange.pipe(filter(e => e.status === 'error'), map(() => { }));
-  @Output() readonly uploadProgress: Observable<number> = this.uploadEventChange.pipe(filter(e => e.status === 'progress'), map((e) => e.progress));
+  @Output() readonly uploadProgress: Observable<number> = this.uploadEventChange
+    .pipe(
+      filter(e => e.status === 'progress'),
+      map((e) => e.progress)
+    );
 
   @Output()
   readonly selectionChange: EventEmitter<File> = new EventEmitter<File>();
@@ -283,18 +281,21 @@ export class SgiFileUploadComponent implements
 
   /** Handles all keydown events on the select. */
   protected handleKeydown(event: KeyboardEvent): void {
-    if (!this.disabled) {
-      const keyCode = event.keyCode;
+    if (this.disabled || hasModifierKey(event)) {
+      return;
+    }
 
-      if ((keyCode === ENTER || keyCode === SPACE) && !hasModifierKey(event)) {
-        event.preventDefault();
-        this.triggerUpload();
-      } else if ((keyCode === BACKSPACE || keyCode === DELETE) && !hasModifierKey(event)) {
-        event.preventDefault();
-        if (this._value) {
-          this._value = null;
-          this.propagateChanges();
-        }
+    const key = event.key;
+
+    if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      this.triggerUpload();
+    } else if (key === 'Backspace' || key === 'Delete') {
+      event.preventDefault();
+
+      if (this._value) {
+        this._value = null;
+        this.propagateChanges();
       }
     }
   }
@@ -403,8 +404,14 @@ export class SgiFileUploadComponent implements
     if (files && files.length) {
       const file = files.item(0);
       if (this.maxFileSizeMb && file.size > this.maxFileSizeMb * 1024 * 1024) {
-        this.selection = null;
-        this.selectionChange.next(null);
+        this.fileUpload.nativeElement.value = null;
+        this._value = {
+          nombre: file.name,
+          tipo: file.type
+        } as IDocumento;
+        this.onChange(null);
+        this.onTouched();
+
         const existing = this.ngControl?.control?.errors ?? {};
         this.ngControl?.control?.setErrors({ ...existing, maxFileSize: true });
         this.changeDetectorRef.markForCheck();


### PR DESCRIPTION
Reordenar campos en Grupos de investigación  - Datos generales:
- Campo código recolocado en la misma fila que acrónimo en la edición. Si existe código de solicitud, se muestran los tres campos (acrónimo, código, solicitud) con el mismo tamaño en una única fila.
- Campo dirección recolocado en la misma fila que email, ocupando el doble de ancho, tanto en creación como en modificación.

Componente sgi-file-upload:
- Al seleccionar un fichero que supera el tamaño máximo permitido, se muestra el nombre del fichero rechazado junto al mensaje de error, en lugar de dejar el campo vacío.
- El error se muestra inmediatamente sin necesidad de hacer clic en otra parte de la pantalla.