### PR TITLE
[#99] [FIX][FRAMEWORK] Fija el path de la cookie CSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [CSP] Se corrige error al clonar una convocatoria cuando sus periodos de justificación tienen observaciones ([#62](https://github.com/herculesproject/sgi/issues/62)).
 - [CSP] Corregido el nombre del concepto de gasto que se mostraba como `[object Object]` en el listado de códigos económicos no permitidos al añadir una partida de gasto en el presupuesto del proyecto ([#74](https://github.com/herculesproject/sgi/issues/74)).
 - [CSP] Corregidos valores NULL en columnas booleanas de `configuracion` en SQL Server y Oracle, donde el valor por defecto no se aplica automáticamente a las filas existentes al añadir columnas ([#90](https://github.com/herculesproject/sgi/issues/90)).
+- Corregido el error 403 (`InvalidCsrfTokenException`) en las peticiones a endpoints públicos (`/public/**`) en despliegues donde los servicios se sirven bajo un prefijo de ruta (`server.servlet.context-path`, p. ej. `/api/csp`), causado por cookies `XSRF-TOKEN` duplicadas con distinto `path`. La cookie CSRF se emite ahora con un `path` fijo (`/` por defecto, configurable con `spring.security.csrf.cookie-path`) ([#99](https://github.com/herculesproject/sgi/issues/99)).
 
 
 

--- a/sgi-framework-spring/src/main/java/org/crue/hercules/sgi/framework/web/config/SgiWebSecurityConfig.java
+++ b/sgi-framework-spring/src/main/java/org/crue/hercules/sgi/framework/web/config/SgiWebSecurityConfig.java
@@ -30,6 +30,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +51,9 @@ public class SgiWebSecurityConfig {
 
   @Value("${spring.security.csrf.enable:true}")
   private boolean csrfEnabled;
+
+  @Value("${spring.security.csrf.cookie-path:/}")
+  private String csrfCookiePath;
 
   @Value("${spring.security.frameoptions.enable:true}")
   private boolean frameoptionsEnabled;
@@ -91,7 +95,7 @@ public class SgiWebSecurityConfig {
       // @formatter:off
       http
         // CSRF protection by cookie
-        .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()));
+        .csrf(csrf -> csrf.csrfTokenRepository(csrfTokenRepository()));
       // @formatter:on
     } else {
       // @formatter:off
@@ -136,8 +140,36 @@ public class SgiWebSecurityConfig {
   }
 
   /**
+   * Creates the {@link CsrfTokenRepository} that stores the CSRF token in a
+   * cookie readable by JavaScript (so the SPA can echo it back in the
+   * {@code X-XSRF-TOKEN} header).
+   * <p>
+   * The cookie path is forced to the value of the
+   * {@code spring.security.csrf.cookie-path} property (defaults to {@code /})
+   * instead of letting {@link CookieCsrfTokenRepository} derive it from the
+   * servlet context path. When several services are served under different path
+   * prefixes on the same host (e.g. {@code /api/csp} behind an ingress that does
+   * not rewrite the prefix, forcing a {@code server.servlet.context-path}),
+   * deriving the path from the context produces {@code XSRF-TOKEN} cookies scoped
+   * to different paths. The browser then keeps several cookies with the same name
+   * and may send a different one than the server validates against, resulting in
+   * spurious {@code 403 Invalid CSRF Token} errors. A fixed path collapses them
+   * into a single cookie. It remains configurable in case a deployment needs a
+   * different scope.
+   *
+   * @return the {@link CsrfTokenRepository}
+   */
+  protected CsrfTokenRepository csrfTokenRepository() {
+    log.debug("csrfTokenRepository() - start");
+    CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+    csrfTokenRepository.setCookiePath(csrfCookiePath);
+    log.debug("csrfTokenRepository() - end");
+    return csrfTokenRepository;
+  }
+
+  /**
    * Creates new {@link KeycloakOidcUserService}.
-   * 
+   *
    * @return the {@link KeycloakOidcUserService}
    */
   protected OAuth2UserService<OidcUserRequest, OidcUser> keycloakOidcUserService() {

--- a/sgi-framework-spring/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/sgi-framework-spring/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,6 +6,12 @@
       "defaultValue": "true"
     },
     {
+      "name": "spring.security.csrf.cookie-path",
+      "type": "java.lang.String",
+      "description": "Path of the CSRF (XSRF-TOKEN) cookie. Forced to a fixed value instead of being derived from the servlet context-path to avoid duplicated XSRF-TOKEN cookies (and spurious 403) when services are served under different path prefixes on the same host.",
+      "defaultValue": "/"
+    },
+    {
       "name": "spring.security.frameoptions.enable",
       "type": "java.lang.Boolean",
       "defaultValue": "true"

--- a/sgi-framework-spring/src/test/java/org/crue/hercules/sgi/framework/integration/SgiWebSecurityConfigCsrfCookiePathIT.java
+++ b/sgi-framework-spring/src/test/java/org/crue/hercules/sgi/framework/integration/SgiWebSecurityConfigCsrfCookiePathIT.java
@@ -1,0 +1,63 @@
+package org.crue.hercules.sgi.framework.integration;
+
+import javax.servlet.http.Cookie;
+
+import org.assertj.core.api.Assertions;
+import org.crue.hercules.sgi.framework.integration.SgiWebSecurityConfigCsrfCookiePathIT.SecurityConfigTest;
+import org.crue.hercules.sgi.framework.web.config.SgiWebSecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Verifies that the CSRF (XSRF-TOKEN) cookie path is configurable through the
+ * {@code spring.security.csrf.cookie-path} property.
+ */
+@WebMvcTest(SecurityConfigTest.class)
+@TestPropertySource(properties = "spring.security.csrf.cookie-path=/api/csp")
+class SgiWebSecurityConfigCsrfCookiePathIT {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  // Required by SgiWebSecurityConfig to configure the oauth2 resource server.
+  // Never invoked by these tests.
+  @MockBean
+  private JwtDecoder jwtDecoder;
+
+  @Test
+  void csrfCookie_isEmittedWithConfiguredPath() throws Exception {
+    // when: a request hits a public (permitAll) endpoint, the CsrfFilter writes
+    // the XSRF-TOKEN cookie
+    MvcResult result = mockMvc
+        .perform(MockMvcRequestBuilders.get("/public/test"))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andReturn();
+
+    // then: the cookie is scoped to the configured path
+    Cookie cookie = result.getResponse().getCookie("XSRF-TOKEN");
+    Assertions.assertThat(cookie).isNotNull();
+    Assertions.assertThat(cookie.getPath()).isEqualTo("/api/csp");
+  }
+
+  @Configuration
+  public static class SecurityConfigTest extends SgiWebSecurityConfig {
+    @RestController
+    public static class InnerSecurityConfigTestController {
+      @GetMapping("/public/test")
+      String test() {
+        return "ok";
+      }
+    }
+  }
+}

--- a/sgi-framework-spring/src/test/java/org/crue/hercules/sgi/framework/integration/SgiWebSecurityConfigIT.java
+++ b/sgi-framework-spring/src/test/java/org/crue/hercules/sgi/framework/integration/SgiWebSecurityConfigIT.java
@@ -1,0 +1,62 @@
+package org.crue.hercules.sgi.framework.integration;
+
+import javax.servlet.http.Cookie;
+
+import org.assertj.core.api.Assertions;
+import org.crue.hercules.sgi.framework.integration.SgiWebSecurityConfigIT.SecurityConfigTest;
+import org.crue.hercules.sgi.framework.web.config.SgiWebSecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Verifies that the CSRF (XSRF-TOKEN) cookie is emitted with the default
+ * {@code /} path, so it is not scoped to a service specific servlet
+ * context-path (which would lead to duplicated cookies and spurious 403).
+ */
+@WebMvcTest(SecurityConfigTest.class)
+class SgiWebSecurityConfigIT {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  // Required by SgiWebSecurityConfig to configure the oauth2 resource server.
+  // Never invoked by these tests.
+  @MockBean
+  private JwtDecoder jwtDecoder;
+
+  @Test
+  void csrfCookie_isEmittedWithDefaultRootPath() throws Exception {
+    // when: a request hits a public (permitAll) endpoint, the CsrfFilter writes
+    // the XSRF-TOKEN cookie
+    MvcResult result = mockMvc
+        .perform(MockMvcRequestBuilders.get("/public/test"))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andReturn();
+
+    // then: the cookie is scoped to the default root path "/"
+    Cookie cookie = result.getResponse().getCookie("XSRF-TOKEN");
+    Assertions.assertThat(cookie).isNotNull();
+    Assertions.assertThat(cookie.getPath()).isEqualTo("/");
+  }
+
+  @Configuration
+  public static class SecurityConfigTest extends SgiWebSecurityConfig {
+    @RestController
+    public static class InnerSecurityConfigTestController {
+      @GetMapping("/public/test")
+      String test() {
+        return "ok";
+      }
+    }
+  }
+}


### PR DESCRIPTION
CookieCsrfTokenRepository derivaba el path de la cookie XSRF-TOKEN del servlet context-path. En despliegues que sirven el servicio bajo un prefijo de ruta (server.servlet.context-path=/api/csp), la cookie se emitía en Path=/api/csp y coexistía con otra XSRF-TOKEN en Path=/, dejando dos cookies con el mismo nombre y distinto path en el navegador.

Esa duplicidad rompía la validación CSRF de las peticiones a los endpoints públicos (/public/**), que terminaban en 403 (InvalidCsrfTokenException). Reproducible en el alta pública de solicitudes (POST /api/csp/public/solicitudes).

Se fija el path de la cookie CSRF a un valor fijo (por defecto "/"), desacoplándolo del context-path, de modo que exista una sola cookie XSRF-TOKEN por dominio. El valor es configurable mediante spring.security.csrf.cookie-path por si algún entorno necesitase otro scope.

- SgiWebSecurityConfig: nueva propiedad spring.security.csrf.cookie-path (default "/") y método protected csrfTokenRepository() que aplica setCookiePath, sustituyendo la creación inline del repositorio.
- additional-spring-configuration-metadata.json: metadata de la nueva propiedad para autocompletado en IDEs y application.yml.
- Tests de integración: SgiWebSecurityConfigIT (path por defecto "/") y SgiWebSecurityConfigCsrfCookiePathIT (path configurable).