### PR TITLE
[#101] [WEB] Mejoras en validadores formly y estilo de los radio buttons en los modales de tablas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [CSP] Corregido el nombre del concepto de gasto que se mostraba como `[object Object]` en el listado de códigos económicos no permitidos al añadir una partida de gasto en el presupuesto del proyecto ([#74](https://github.com/herculesproject/sgi/issues/74)).
 - [CSP] Corregidos valores NULL en columnas booleanas de `configuracion` en SQL Server y Oracle, donde el valor por defecto no se aplica automáticamente a las filas existentes al añadir columnas ([#90](https://github.com/herculesproject/sgi/issues/90)).
 - Corregido el error 403 (`InvalidCsrfTokenException`) en las peticiones a endpoints públicos (`/public/**`) en despliegues donde los servicios se sirven bajo un prefijo de ruta (`server.servlet.context-path`, p. ej. `/api/csp`), causado por cookies `XSRF-TOKEN` duplicadas con distinto `path`. La cookie CSRF se emite ahora con un `path` fijo (`/` por defecto, configurable con `spring.security.csrf.cookie-path`) ([#99](https://github.com/herculesproject/sgi/issues/99)).
+- [WEB] Corregido un error al usar validaciones a nivel de formulario (p. ej., la comparación de fechas entre campos) cuando el apartado o el campo implicado está oculto ([#101](https://github.com/herculesproject/sgi/issues/101)).
 
 
 
@@ -45,6 +46,9 @@
 - [CSP] Ampliado el tamaño máximo de los campos título (1000 caracteres) y observaciones (8000 caracteres) del proyecto ([#63](https://github.com/herculesproject/sgi/issues/63)).
 - [CSP] Ampliado el tamaño máximo del campo nombre (550 caracteres) de la fuente de financiación ([#64](https://github.com/herculesproject/sgi/issues/64)).
 - [ETI] Añadir reemplazo de placeholders de nombre de comité en esquemas Formly para el contexto dev ([#36](https://github.com/herculesproject/sgi/issues/36)).
+
+### Security
+- [WEB] Eliminado el uso de `eval` en la generación de los mensajes personalizados de los validadores de los formularios dinámicos (formly), que permitía ejecutar código arbitrario desde mensajes configurables externamente (clobs en BD, integraciones) ([#101](https://github.com/herculesproject/sgi/issues/101)).
 
 ## 1.0.0 (2026-02-26)
 

--- a/sgi-webapp/src/app/esb/shared/formly-forms/types/table-crud/table-crud-modal/table-crud-modal.component.scss
+++ b/sgi-webapp/src/app/esb/shared/formly-forms/types/table-crud/table-crud-modal/table-crud-modal.component.scss
@@ -5,6 +5,10 @@
     display: block;
   }
 
+  formly-field-mat-radio mat-radio-button {
+    padding: 5px 15px 0px 0px;
+  }
+
   formly-validation-message {
     color: map-get($palette-warn, $warn-color);
     font-size: 75%;

--- a/sgi-webapp/src/app/formly-forms/validators/date.validator.ts
+++ b/sgi-webapp/src/app/formly-forms/validators/date.validator.ts
@@ -6,15 +6,17 @@ import { DateTime } from 'luxon';
 import { IValidationError } from './models/validation-error';
 import { IValidatorCompareToOptions } from './models/validator-compare-to-options';
 import { IValidatorOptions } from './models/validator-options';
-import { getOptionsCompareValues as getCompareValue } from './utils.validator';
+import { buildCustomMessage, getOptionsCompareValues as getCompareValue } from './utils.validator';
 
 const MSG_FORMLY_VALIDATIONS_DATE_IS_AFTER = marker('msg.formly.validations.date-is-after');
 const MSG_FORMLY_VALIDATIONS_DATE_IS_BETWEEN = marker('msg.formly.validations.date-is-between');
 
-export interface IDateValidatorOptions extends IValidatorOptions, Partial<Pick<IValidatorCompareToOptions, 'formStateProperty' | 'value'>> {
+export interface IDateValidatorOptions
+  extends IValidatorOptions, Partial<Pick<IValidatorCompareToOptions, 'formStateProperty' | 'value'>> {
 }
 
-export interface IDateBetweenValidatorOptions extends IValidatorOptions, Partial<Pick<IValidatorCompareToOptions, 'formStateProperties' | 'values'>> {
+export interface IDateBetweenValidatorOptions
+  extends IValidatorOptions, Partial<Pick<IValidatorCompareToOptions, 'formStateProperties' | 'values'>> {
 }
 
 export function dateIsAfter(
@@ -24,10 +26,14 @@ export function dateIsAfter(
   translate: TranslateService
 ): IValidationError {
   let valueToCompare: DateTime | string = getCompareValue(field.options.formState, options);
-  let controlValue: DateTime | string = options.errorPath ? control.value[options.errorPath] : control.value;
+  let controlValue: DateTime | string = options.errorPath ? control.value?.[options.errorPath] : control.value;
+
+  if (!controlValue) {
+    return null;
+  }
 
   if (control instanceof FormGroup && options.errorPath && options.compareTo === 'formStateProperty') {
-    control.controls[options.errorPath].markAsTouched();
+    control.controls[options.errorPath]?.markAsTouched();
   }
 
   if (typeof valueToCompare === 'string') {
@@ -44,7 +50,10 @@ export function dateIsAfter(
 
   return {
     name: 'date-is-after',
-    customMessage: options.message ? eval('`' + options.message + '`') : null,
+    customMessage: buildCustomMessage(options.message, {
+      controlValue: controlValue.setLocale(translate.currentLang).toLocaleString(DateTime.DATE_SHORT),
+      valueToCompare: valueToCompare.setLocale(translate.currentLang).toLocaleString(DateTime.DATE_SHORT)
+    }),
     defatultMessage: translate.instant(
       MSG_FORMLY_VALIDATIONS_DATE_IS_AFTER,
       {
@@ -60,8 +69,12 @@ export function dateIsBetween(
   options: IDateBetweenValidatorOptions,
   translate: TranslateService
 ): IValidationError {
-  let [minDate, maxDate]: (DateTime | string)[] = getCompareValue(field.options.formState, options);
-  let controlValue: DateTime | string = options.errorPath ? control.value[options.errorPath] : control.value;
+  let [minDate, maxDate]: (DateTime | string)[] = getCompareValue(field.options.formState, options) ?? [];
+  let controlValue: DateTime | string = options.errorPath ? control.value?.[options.errorPath] : control.value;
+
+  if (!controlValue) {
+    return null;
+  }
 
   if (typeof minDate === 'string') {
     minDate = DateTime.fromISO(minDate);
@@ -81,7 +94,11 @@ export function dateIsBetween(
 
   return {
     name: 'date-is-between',
-    customMessage: options.message ? eval('`' + options.message + '`') : null,
+    customMessage: buildCustomMessage(options.message, {
+      controlValue: controlValue.setLocale(translate.currentLang).toLocaleString(DateTime.DATE_SHORT),
+      minDate: minDate.setLocale(translate.currentLang).toLocaleString(DateTime.DATE_SHORT),
+      maxDate: maxDate.setLocale(translate.currentLang).toLocaleString(DateTime.DATE_SHORT)
+    }),
     defatultMessage: translate.instant(
       MSG_FORMLY_VALIDATIONS_DATE_IS_BETWEEN,
       {
@@ -91,3 +108,4 @@ export function dateIsBetween(
     )
   };
 }
+

--- a/sgi-webapp/src/app/formly-forms/validators/email-principal-unique.validator.ts
+++ b/sgi-webapp/src/app/formly-forms/validators/email-principal-unique.validator.ts
@@ -4,6 +4,7 @@ import { SgiFormlyFieldConfig } from '@formly-forms/formly-field-config';
 import { TranslateService } from '@ngx-translate/core';
 import { IValidationError } from './models/validation-error';
 import { IValidatorOptions } from './models/validator-options';
+import { buildCustomMessage } from './utils.validator';
 
 const MSG_FORMLY_VALIDATIONS_EMAIL_PRINCIPAL_UNIQUE = marker('msg.formly.validations.email-principal-unique');
 const MSG_FORMLY_VALIDATIONS_EMAIL_PRINCIPAL_REQUIRED = marker('msg.formly.validations.email-principal-required');
@@ -28,16 +29,16 @@ export function emailPrincipalUniqueValidator(
   let customMessage: string;
   let defatultMessage: string;
   if (controlValues.some(c => c.principal)) {
-    customMessage = options.messagePrincipalUnique ? eval('`' + options.messagePrincipalUnique + '`') : null;
+    customMessage = buildCustomMessage(options.messagePrincipalUnique);
     defatultMessage = MSG_FORMLY_VALIDATIONS_EMAIL_PRINCIPAL_UNIQUE;
   } else {
-    customMessage = options.messagePrincipalRequired ? eval('`' + options.messagePrincipalRequired + '`') : null;
+    customMessage = buildCustomMessage(options.messagePrincipalRequired);
     defatultMessage = MSG_FORMLY_VALIDATIONS_EMAIL_PRINCIPAL_REQUIRED;
   }
 
   return {
     name: 'email-principal-unique',
-    customMessage: customMessage,
-    defatultMessage: defatultMessage
-  }
+    customMessage,
+    defatultMessage
+  };
 }

--- a/sgi-webapp/src/app/formly-forms/validators/email.validator.ts
+++ b/sgi-webapp/src/app/formly-forms/validators/email.validator.ts
@@ -4,6 +4,7 @@ import { SgiFormlyFieldConfig } from '@formly-forms/formly-field-config';
 import { TranslateService } from '@ngx-translate/core';
 import { IValidationError } from './models/validation-error';
 import { IValidatorOptions } from './models/validator-options';
+import { buildCustomMessage } from './utils.validator';
 
 const MSG_FORMLY_VALIDATIONS_EMAIL = marker('msg.formly.validations.email');
 
@@ -22,7 +23,7 @@ export function emailValidator(
 
   return {
     name: 'email',
-    customMessage: options.message ? eval('`' + options.message + '`') : null,
+    customMessage: buildCustomMessage(options.message, { controlValue: control.value }),
     defatultMessage: translate.instant(MSG_FORMLY_VALIDATIONS_EMAIL)
   };
 }

--- a/sgi-webapp/src/app/formly-forms/validators/field-array-max.validator.ts
+++ b/sgi-webapp/src/app/formly-forms/validators/field-array-max.validator.ts
@@ -4,6 +4,7 @@ import { SgiFormlyFieldConfig } from '@formly-forms/formly-field-config';
 import { TranslateService } from '@ngx-translate/core';
 import { IValidationError } from './models/validation-error';
 import { IValidatorOptions } from './models/validator-options';
+import { buildCustomMessage } from './utils.validator';
 
 const MSG_FORMLY_VALIDATIONS_FIELD_ARRAY_MAX = marker('msg.formly.validations.field-array-max');
 
@@ -26,11 +27,11 @@ export function fieldArrayMax(
 
   return {
     name: 'field-array-max',
-    customMessage: options.message ? eval('`' + options.message.replace('{{max}}', max.toString()) + '`') : null,
+    customMessage: buildCustomMessage(options.message, { max }),
     defatultMessage: translate.instant(
       MSG_FORMLY_VALIDATIONS_FIELD_ARRAY_MAX,
       {
-        max: max
+        max
       }
     )
   };

--- a/sgi-webapp/src/app/formly-forms/validators/multicheckbox.validator.ts
+++ b/sgi-webapp/src/app/formly-forms/validators/multicheckbox.validator.ts
@@ -5,6 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { IValidationError } from './models/validation-error';
 import { IValidatorOptions } from './models/validator-options';
+import { buildCustomMessage } from './utils.validator';
 
 const MSG_FORMLY_VALIDATIONS_MULTICHECKBOX_RESTRICTED = marker('msg.formly.validations.multicheckbox-restricted');
 
@@ -14,12 +15,12 @@ export interface IMulticheckboxValidatorOptions extends IValidatorOptions {
       option: string,
       incompatibleOptions: string[]
     }[]
-  }
+  };
 }
 
 interface IMulticheckboxOption {
-  value: string,
-  label: string
+  value: string;
+  label: string;
 }
 
 interface IIncompatibilities {
@@ -45,12 +46,12 @@ export function multicheckboxRestricted(
 
   return {
     name: 'multicheckbox-restricted',
-    customMessage: options.message ? eval('`' + options.message + '`') : null,
+    customMessage: buildCustomMessage(options.message, { option1, option2 }),
     defatultMessage: translate.instant(
       MSG_FORMLY_VALIDATIONS_MULTICHECKBOX_RESTRICTED,
       {
-        option1: option1,
-        option2: option2
+        option1,
+        option2
       }
     )
   };
@@ -61,11 +62,11 @@ function getIncompatibleOptions(controlValues: string[], options: IMulticheckbox
     return null;
   }
 
-  let currentControlValue = controlValues.shift();
+  const currentControlValue = controlValues.shift();
 
   const incompatibleOptions = options.restrictions.notValidCombinations.find(c => c.option === currentControlValue)?.incompatibleOptions;
   const incompatibility = incompatibleOptions.find(option => controlValues.includes(option));
-  if (!!incompatibility) {
+  if (incompatibility) {
     return {
       option1: currentControlValue,
       option2: incompatibility
@@ -83,4 +84,4 @@ function getDisplayValue(options: IMulticheckboxOption[] | Observable<IMultichec
   if (Array.isArray(options)) {
     return options.find(option => option.value === optionValue)?.label ?? optionValue;
   }
-} 
+}

--- a/sgi-webapp/src/app/formly-forms/validators/utils.validator.ts
+++ b/sgi-webapp/src/app/formly-forms/validators/utils.validator.ts
@@ -1,6 +1,6 @@
 import { FormArray, FormGroup, ValidationErrors } from '@angular/forms';
-import { IValidatorOptions } from './models/validator-options';
 import { IValidatorCompareToOptions } from './models/validator-compare-to-options';
+import { IValidatorOptions } from './models/validator-options';
 
 
 export function requiredChecked(formGroup: FormGroup): ValidationErrors {
@@ -65,4 +65,36 @@ function getFormStateProperty(formState: any, propertyPath: string[]): any {
   }
 
   return formState[currentPath];
+}
+
+/**
+ * Interpola en `message` los placeholders cuyo nombre esté presente en `variables`.
+ *
+ * Se admiten dos sintaxis: `${variable}` (forma canónica) y `{{variable}}` (aceptada por
+ * compatibilidad con mensajes provenientes de integraciones externas). Solo se sustituyen nombres
+ * de variable (`\w+`) del diccionario proporcionado; cualquier otro placeholder se deja intacto.
+ * No se evalúan expresiones, por lo que el mensaje, aunque sea configurable externamente, no puede
+ * ejecutar código.
+ *
+ * @param message plantilla del mensaje (puede ser null/undefined)
+ * @param variables variables permitidas para la interpolación
+ * @returns el mensaje interpolado, o null si no hay mensaje
+ */
+export function buildCustomMessage(
+  message: string | null | undefined,
+  variables: Record<string, unknown> = {}
+): string | null {
+  if (!message) {
+    return null;
+  }
+
+  return message.replace(
+    /\$\{(\w+)\}|\{\{(\w+)\}\}/g,
+    (match, dollarName, braceName) => {
+      const variableName = dollarName ?? braceName;
+      return variableName in variables
+        ? String(variables[variableName])
+        : match;
+    }
+  );
 }


### PR DESCRIPTION
Validaciones a nivel de formulario:
- dateIsAfter y dateIsBetween dejan de fallar cuando el apartado o el campo sobre el que operan está oculto o deshabilitado: se accede a control.value  de forma segura y se omite la validación cuando no hay valor que comprobar.

Mensajes personalizados:
- Se elimina eval, que permitía ejecutar código arbitrario desde mensajes configurables externamente (clobs en BD, integraciones).
- La interpolación se centraliza en buildCustomMessage (utils.validator), que solo sustituye variables conocidas y admite las sintaxis ${var} y {{var}}.
- Se aplica en date, email, multicheckbox, email-principal-unique y field-array-max.

Estilo de los radio buttons :
- Se añade separación entre las opciones de los radio buttons en los modales de tablas de formly
