### PR TITLE
[#103] [BUG][CSP][CON] Preservar campos de auditoría al modificar convocatoria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
        ### Fixed            Corrección de errores
        ### Security         Correcciones de vulnerabilidades
 -->
+
+### Fixed
+- [CSP][CON] Corregida la pérdida de los campos de auditoría de creación (`created_by`, `creation_date`) al modificar una convocatoria y sus entidades relacionadas ([#103](https://github.com/herculesproject/sgi/issues/103)).
+
 ## 1.1.0 (2026-06-11)
 
 **Notas de actualización:** [1.1.0](/docs/upgrade/1.1.0.md)

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/model/Convocatoria.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/model/Convocatoria.java
@@ -49,6 +49,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SuppressWarnings("java:S6539")
 public class Convocatoria extends BaseEntity {
 
   /**
@@ -178,91 +179,109 @@ public class Convocatoria extends BaseEntity {
   @OneToOne(mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final ConfiguracionSolicitud configuracionSolicitud = null;
 
   @OneToOne(mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final RequisitoEquipo requisitoEquipo = null;
 
   @OneToOne(mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final RequisitoIP requisitoIP = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaAreaTematica> areasTematicas = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaConceptoGasto> conceptosGasto = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaDocumento> documentos = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaEnlace> enlaces = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaEntidadConvocante> entidadesConvocantes = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaEntidadFinanciadora> entidadesFinanciadoras = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaEntidadGestora> entidadesGestoras = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaFase> fases = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaHito> hitos = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaPeriodoJustificacion> periodosJustificacion = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaPeriodoSeguimientoCientifico> periodosSeguimiento = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<Proyecto> proyectos = null;
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<Solicitud> solicitudes = null;
 
   @OneToMany(mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaPalabraClave> palabrasClave = null;
 
   @OneToMany(mappedBy = "convocatoria")
   @Getter(AccessLevel.NONE)
   @Setter(AccessLevel.NONE)
+  @SuppressWarnings("java:S1170")
   private final List<ConvocatoriaPartida> partidas = null;
 
 }

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConfiguracionSolicitudServiceImpl.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConfiguracionSolicitudServiceImpl.java
@@ -88,7 +88,7 @@ public class ConfiguracionSolicitudServiceImpl implements ConfiguracionSolicitud
   @Override
   @Transactional
   public ConfiguracionSolicitud update(ConfiguracionSolicitud configuracionSolicitud, Long convocatoriaId) {
-    log.debug("update(ConfiguracionSolicitud configuracionSolicitud) - start");
+    log.debug("update - convocatoriaId: {}, data: {}", convocatoriaId, configuracionSolicitud);
 
     AssertHelper.idNotNull(convocatoriaId, Convocatoria.class);
 
@@ -101,10 +101,7 @@ public class ConfiguracionSolicitudServiceImpl implements ConfiguracionSolicitud
       data.setFasePresentacionSolicitudes(configuracionSolicitud.getFasePresentacionSolicitudes());
       data.setImporteMaximoSolicitud(configuracionSolicitud.getImporteMaximoSolicitud());
 
-      ConfiguracionSolicitud returnValue = repository.save(configuracionSolicitud);
-
-      log.debug("update(ConfiguracionSolicitud configuracionSolicitud) - end");
-      return returnValue;
+      return repository.save(data);
     }).orElseThrow(() -> new ConfiguracionSolicitudNotFoundException(configuracionSolicitud.getId()));
   }
 

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConvocatoriaAreaTematicaServiceImpl.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConvocatoriaAreaTematicaServiceImpl.java
@@ -110,16 +110,15 @@ public class ConvocatoriaAreaTematicaServiceImpl implements ConvocatoriaAreaTema
   @Override
   @Transactional
   public ConvocatoriaAreaTematica update(ConvocatoriaAreaTematica convocatoriaAreaTematicaActualizar) {
-    log.debug("update(ConvocatoriaAreaTematica convocatoriaAreaTematicaActualizar) - start");
+    log.debug("update - id: {}, data: {}", convocatoriaAreaTematicaActualizar.getId(),
+        convocatoriaAreaTematicaActualizar);
 
     AssertHelper.idNotNull(convocatoriaAreaTematicaActualizar.getId(), ConvocatoriaAreaTematica.class);
 
     return repository.findById(convocatoriaAreaTematicaActualizar.getId()).map(convocatoriaAreaTematica -> {
-
+      convocatoriaAreaTematica.setAreaTematica(convocatoriaAreaTematicaActualizar.getAreaTematica());
       convocatoriaAreaTematica.setObservaciones(convocatoriaAreaTematicaActualizar.getObservaciones());
-      ConvocatoriaAreaTematica returnValue = repository.save(convocatoriaAreaTematicaActualizar);
-      log.debug("update(ConvocatoriaAreaTematica convocatoriaAreaTematicaActualizar) - end");
-      return returnValue;
+      return repository.save(convocatoriaAreaTematica);
     }).orElseThrow(() -> new ConvocatoriaAreaTematicaNotFoundException(convocatoriaAreaTematicaActualizar.getId()));
   }
 

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConvocatoriaPartidaServiceImpl.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConvocatoriaPartidaServiceImpl.java
@@ -87,18 +87,18 @@ public class ConvocatoriaPartidaServiceImpl implements ConvocatoriaPartidaServic
   @Transactional
   @Validated({ BaseEntity.Update.class })
   public ConvocatoriaPartida update(@Valid ConvocatoriaPartida convocatoriaPartidaActualizar) {
-    log.debug("update(ConvocatoriaPartida convocatoriaPartidaActualizar) - start");
+    log.debug("update - id: {}, data: {}", convocatoriaPartidaActualizar.getId(),
+        convocatoriaPartidaActualizar);
 
     AssertHelper.idNotNull(convocatoriaPartidaActualizar.getId(), ConvocatoriaPartida.class);
     this.validate(convocatoriaPartidaActualizar);
 
-    // Restricción de convocatorias asociadas a proyectos con presupuesto
-
     return repository.findById(convocatoriaPartidaActualizar.getId()).map(convocatoriaPartida -> {
-
-      ConvocatoriaPartida returnValue = repository.save(convocatoriaPartidaActualizar);
-      log.debug("update(ConvocatoriaPartida convocatoriaPartidaActualizar) - end");
-      return returnValue;
+      convocatoriaPartida.setCodigo(convocatoriaPartidaActualizar.getCodigo());
+      convocatoriaPartida.setPartidaRef(convocatoriaPartidaActualizar.getPartidaRef());
+      convocatoriaPartida.setDescripcion(convocatoriaPartidaActualizar.getDescripcion());
+      convocatoriaPartida.setTipoPartida(convocatoriaPartidaActualizar.getTipoPartida());
+      return repository.save(convocatoriaPartida);
     }).orElseThrow(() -> new ConvocatoriaPartidaNotFoundException(convocatoriaPartidaActualizar.getId()));
   }
 

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConvocatoriaServiceImpl.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ConvocatoriaServiceImpl.java
@@ -16,6 +16,7 @@ import org.crue.hercules.sgi.csp.model.ConfiguracionSolicitud;
 import org.crue.hercules.sgi.csp.model.Convocatoria;
 import org.crue.hercules.sgi.csp.model.ConvocatoriaFase;
 import org.crue.hercules.sgi.csp.model.ConvocatoriaPeriodoSeguimientoCientifico;
+import org.crue.hercules.sgi.csp.model.Identifiable;
 import org.crue.hercules.sgi.csp.model.ModeloEjecucion;
 import org.crue.hercules.sgi.csp.model.ModeloTipoFinalidad;
 import org.crue.hercules.sgi.csp.model.ModeloUnidad;
@@ -167,8 +168,8 @@ public class ConvocatoriaServiceImpl implements ConvocatoriaService {
     convocatoria.setEstado(Convocatoria.Estado.BORRADOR);
     convocatoria.setActivo(Boolean.TRUE);
 
-    Convocatoria validConvocatoria = validarDatosConvocatoria(convocatoria, null);
-    Convocatoria returnValue = repository.save(validConvocatoria);
+    validarDatosConvocatoria(convocatoria, null);
+    Convocatoria returnValue = repository.save(convocatoria);
 
     log.debug("create(Convocatoria convocatoria) - end");
     return returnValue;
@@ -191,29 +192,29 @@ public class ConvocatoriaServiceImpl implements ConvocatoriaService {
 
     return repository.findById(convocatoria.getId()).map(data -> {
       authorityHelper.checkUserHasAuthorityModifyConvocatoria(data);
-      Convocatoria validConvocatoria = validarDatosConvocatoria(convocatoria, data);
+      validarDatosConvocatoria(convocatoria, data);
 
-      data.setUnidadGestionRef(validConvocatoria.getUnidadGestionRef());
-      data.setModeloEjecucion(validConvocatoria.getModeloEjecucion());
-      data.setCodigo(validConvocatoria.getCodigo());
-      data.setFechaPublicacion(validConvocatoria.getFechaPublicacion());
-      data.setFechaProvisional(validConvocatoria.getFechaProvisional());
-      data.setFechaConcesion(validConvocatoria.getFechaConcesion());
-      data.setTitulo(validConvocatoria.getTitulo());
-      data.setObjeto(validConvocatoria.getObjeto());
-      data.setObservaciones(validConvocatoria.getObservaciones());
-      data.setFinalidad(validConvocatoria.getFinalidad());
-      data.setRegimenConcurrencia(validConvocatoria.getRegimenConcurrencia());
-      data.setFormularioSolicitud(validConvocatoria.getFormularioSolicitud());
-      data.setDuracion(validConvocatoria.getDuracion());
-      data.setAmbitoGeografico(validConvocatoria.getAmbitoGeografico());
-      data.setClasificacionCVN(validConvocatoria.getClasificacionCVN());
-      data.setActivo(validConvocatoria.getActivo());
-      data.setExcelencia(validConvocatoria.getExcelencia());
-      data.setCodigoInterno(validConvocatoria.getCodigoInterno());
-      data.setAnio(validConvocatoria.getAnio());
+      data.setActivo(convocatoria.getActivo());
+      data.setAmbitoGeografico(convocatoria.getAmbitoGeografico());
+      data.setAnio(convocatoria.getAnio());
+      data.setClasificacionCVN(convocatoria.getClasificacionCVN());
+      data.setCodigo(convocatoria.getCodigo());
+      data.setCodigoInterno(convocatoria.getCodigoInterno());
+      data.setDuracion(convocatoria.getDuracion());
+      data.setExcelencia(convocatoria.getExcelencia());
+      data.setFechaConcesion(convocatoria.getFechaConcesion());
+      data.setFechaProvisional(convocatoria.getFechaProvisional());
+      data.setFechaPublicacion(convocatoria.getFechaPublicacion());
+      data.setFinalidad(convocatoria.getFinalidad());
+      data.setFormularioSolicitud(convocatoria.getFormularioSolicitud());
+      data.setModeloEjecucion(convocatoria.getModeloEjecucion());
+      data.setObjeto(convocatoria.getObjeto());
+      data.setObservaciones(convocatoria.getObservaciones());
+      data.setRegimenConcurrencia(convocatoria.getRegimenConcurrencia());
+      data.setTitulo(convocatoria.getTitulo());
+      data.setUnidadGestionRef(convocatoria.getUnidadGestionRef());
 
-      Convocatoria returnValue = repository.save(validConvocatoria);
+      Convocatoria returnValue = repository.save(data);
 
       log.debug("update(Convocatoria convocatoria) - end");
       return returnValue;
@@ -637,14 +638,27 @@ public class ConvocatoriaServiceImpl implements ConvocatoriaService {
   }
 
   /**
-   * Comprueba y valida los datos de una convocatoria.
-   * 
-   * @param datosConvocatoria
-   * @param datosOriginales
-   * @return convocatoria con los datos validados
+   * Comprueba y valida los datos de una {@link Convocatoria} y sus entidades
+   * relacionadas (disponibilidad y estado activo).
+   *
+   * @param datosConvocatoria datos de la {@link Convocatoria} a validar.
+   * @param datosOriginales   datos actuales de la {@link Convocatoria}.
    */
-  private Convocatoria validarDatosConvocatoria(Convocatoria datosConvocatoria, Convocatoria datosOriginales) {
+  private void validarDatosConvocatoria(Convocatoria datosConvocatoria, Convocatoria datosOriginales) {
     log.debug("validarDatosConvocatoria(Convocatoria datosConvocatoria, Convocatoria datosOriginales) - start");
+
+    if (isEntityWithoutId(datosConvocatoria.getModeloEjecucion())) {
+      datosConvocatoria.setModeloEjecucion(null);
+    }
+    if (isEntityWithoutId(datosConvocatoria.getFinalidad())) {
+      datosConvocatoria.setFinalidad(null);
+    }
+    if (isEntityWithoutId(datosConvocatoria.getRegimenConcurrencia())) {
+      datosConvocatoria.setRegimenConcurrencia(null);
+    }
+    if (isEntityWithoutId(datosConvocatoria.getAmbitoGeografico())) {
+      datosConvocatoria.setAmbitoGeografico(null);
+    }
 
     // Campos obligatorios en estado Registrada
     if (datosConvocatoria.getEstado() == Convocatoria.Estado.REGISTRADA) {
@@ -730,7 +744,6 @@ public class ConvocatoriaServiceImpl implements ConvocatoriaService {
                 .parameter(MSG_KEY_FIELD, modeloUnidad.get().getModeloEjecucion().getNombre())
                 .build());
       }
-      datosConvocatoria.setModeloEjecucion(modeloUnidad.get().getModeloEjecucion());
     }
 
     // TipoFinalidad
@@ -774,36 +787,30 @@ public class ConvocatoriaServiceImpl implements ConvocatoriaService {
                 .parameter(MSG_KEY_FIELD, modeloTipoFinalidad.get().getTipoFinalidad().getNombre())
                 .build());
       }
-      datosConvocatoria.setFinalidad(modeloTipoFinalidad.get().getTipoFinalidad());
     }
 
     // TipoRegimenConcurrencia
     if (datosConvocatoria.getRegimenConcurrencia() != null) {
-      if (datosConvocatoria.getRegimenConcurrencia().getId() == null) {
-        datosConvocatoria.setRegimenConcurrencia(null);
-      } else {
 
-        Optional<TipoRegimenConcurrencia> tipoRegimenConcurrencia = tipoRegimenConcurrenciaRepository
-            .findById(datosConvocatoria.getRegimenConcurrencia().getId());
+      Optional<TipoRegimenConcurrencia> tipoRegimenConcurrencia = tipoRegimenConcurrenciaRepository
+          .findById(datosConvocatoria.getRegimenConcurrencia().getId());
 
-        Assert.isTrue(tipoRegimenConcurrencia.isPresent(),
+      Assert.isTrue(tipoRegimenConcurrencia.isPresent(),
+          () -> ProblemMessage.builder()
+              .key(MSG_ENTITY_EXISTS)
+              .parameter(MSG_KEY_ENTITY, ApplicationContextSupport.getMessage(MSG_MODEL_TIPO_REGIMEN_CONCURRENCIA))
+              .parameter(MSG_KEY_FIELD, datosConvocatoria.getRegimenConcurrencia().getNombre())
+              .build());
+
+      // Permitir no activos solo si estamos modificando y es el mismo
+      if (datosOriginales == null || (datosOriginales.getRegimenConcurrencia() != null
+          && (!tipoRegimenConcurrencia.get().getId().equals(datosOriginales.getRegimenConcurrencia().getId())))) {
+        Assert.isTrue(tipoRegimenConcurrencia.get().getActivo(),
             () -> ProblemMessage.builder()
-                .key(MSG_ENTITY_EXISTS)
+                .key(MSG_ENTITY_INACTIVO)
                 .parameter(MSG_KEY_ENTITY, ApplicationContextSupport.getMessage(MSG_MODEL_TIPO_REGIMEN_CONCURRENCIA))
-                .parameter(MSG_KEY_FIELD, datosConvocatoria.getRegimenConcurrencia().getNombre())
+                .parameter(MSG_KEY_FIELD, tipoRegimenConcurrencia.get().getNombre())
                 .build());
-
-        // Permitir no activos solo si estamos modificando y es el mismo
-        if (datosOriginales == null || (datosOriginales.getRegimenConcurrencia() != null
-            && (!tipoRegimenConcurrencia.get().getId().equals(datosOriginales.getRegimenConcurrencia().getId())))) {
-          Assert.isTrue(tipoRegimenConcurrencia.get().getActivo(),
-              () -> ProblemMessage.builder()
-                  .key(MSG_ENTITY_INACTIVO)
-                  .parameter(MSG_KEY_ENTITY, ApplicationContextSupport.getMessage(MSG_MODEL_TIPO_REGIMEN_CONCURRENCIA))
-                  .parameter(MSG_KEY_FIELD, tipoRegimenConcurrencia.get().getNombre())
-                  .build());
-        }
-        datosConvocatoria.setRegimenConcurrencia(tipoRegimenConcurrencia.get());
       }
     }
 
@@ -825,7 +832,6 @@ public class ConvocatoriaServiceImpl implements ConvocatoriaService {
                 .parameter(MSG_KEY_FIELD, tipoAmbitoGeografico.get().getNombre())
                 .build());
       }
-      datosConvocatoria.setAmbitoGeografico(tipoAmbitoGeografico.get());
     }
 
     // Comprueba que la duracion no sea menor que el ultimo mes del ultimo
@@ -854,8 +860,16 @@ public class ConvocatoriaServiceImpl implements ConvocatoriaService {
     }
 
     log.debug("validarDatosConvocatoria(Convocatoria datosConvocatoria, Convocatoria datosOriginales) - end");
+  }
 
-    return datosConvocatoria;
+  /**
+   * Indica si una entidad relacionada se ha recibido sin id.
+   *
+   * @param entity entidad relacionada.
+   * @return {@code true} si la entidad no es {@code null} pero no tiene id.
+   */
+  private static boolean isEntityWithoutId(Identifiable entity) {
+    return entity != null && entity.getId() == null;
   }
 
   /**

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConfiguracionSolicitudIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConfiguracionSolicitudIT.java
@@ -49,8 +49,7 @@ class ConfiguracionSolicitudIT extends BaseIT {
     headers.set("Authorization", String.format("bearer %s",
         tokenBuilder.buildToken("user", "CSP-CON-C", "CSP-CON-E", "CSP-CON-B", "CSP-CON-V", "CSP-SOL-V")));
 
-    HttpEntity<ConfiguracionSolicitud> request = new HttpEntity<>(entity, headers);
-    return request;
+    return new HttpEntity<>(entity, headers);
   }
 
   @Sql
@@ -79,6 +78,10 @@ class ConfiguracionSolicitudIT extends BaseIT {
         .isEqualTo(configuracionSolicitud.getFasePresentacionSolicitudes().getId());
     Assertions.assertThat(responseData.getImporteMaximoSolicitud()).as("getImporteMaximoSolicitud()")
         .isEqualTo(configuracionSolicitud.getImporteMaximoSolicitud());
+    Assertions.assertThat(responseData.getCreatedBy()).as("getCreatedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.getCreationDate()).as("getCreationDate()").isNotNull();
+    Assertions.assertThat(responseData.getLastModifiedBy()).as("getLastModifiedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.getLastModifiedDate()).as("getLastModifiedDate()").isNotNull();
   }
 
   @Sql
@@ -110,6 +113,13 @@ class ConfiguracionSolicitudIT extends BaseIT {
         .as("getFasePresentacionSolicitudes().getId()").isEqualTo(2L);
     Assertions.assertThat(responseData.getImporteMaximoSolicitud()).as("getImporteMaximoSolicitud()")
         .isEqualTo(BigDecimal.valueOf(54321));
+    Assertions.assertThat(responseData.getCreatedBy()).as("getCreatedBy()").isEqualTo("original-user");
+    Assertions.assertThat(responseData.getCreationDate()).as("getCreationDate()")
+        .isEqualTo(Instant.parse("2021-01-01T00:00:00Z"));
+    Assertions.assertThat(responseData.getLastModifiedBy()).as("getLastModifiedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.getLastModifiedDate()).as("getLastModifiedDate()")
+        .isNotNull()
+        .isNotEqualTo(Instant.parse("2021-01-01T00:00:00Z"));
   }
 
   @Sql
@@ -256,7 +266,6 @@ class ConfiguracionSolicitudIT extends BaseIT {
     Set<TipoFaseNombre> nombreTipoFase = new HashSet<>();
     nombreTipoFase.add(new TipoFaseNombre(Language.ES, "nombre-1"));
 
-    // @formatter:off
     TipoFase tipoFase = TipoFase.builder()
         .id(convocatoriaFaseId)
         .nombre(nombreTipoFase)
@@ -275,16 +284,13 @@ class ConfiguracionSolicitudIT extends BaseIT {
         .observaciones(obsConvocatoriaFase)
         .build();
 
-    ConfiguracionSolicitud configuracionSolicitud = ConfiguracionSolicitud.builder()
+    return ConfiguracionSolicitud.builder()
         .id(configuracionSolicitudId)
         .convocatoriaId(convocatoriaId)
         .tramitacionSGI(Boolean.TRUE)
         .fasePresentacionSolicitudes(convocatoriaFase)
         .importeMaximoSolicitud(BigDecimal.valueOf(12345))
         .build();
-    // @formatter:on
-
-    return configuracionSolicitud;
   }
 
 }

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaAreaTematicaIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaAreaTematicaIT.java
@@ -1,5 +1,6 @@
 package org.crue.hercules.sgi.csp.integration;
 
+import java.time.Instant;
 import java.util.Collections;
 
 import org.assertj.core.api.Assertions;
@@ -32,8 +33,7 @@ class ConvocatoriaAreaTematicaIT extends BaseIT {
     headers.set("Authorization",
         String.format("bearer %s", tokenBuilder.buildToken("user", "AUTH", "CSP-CON-C", "CSP-CON-E")));
 
-    HttpEntity<ConvocatoriaAreaTematica> request = new HttpEntity<>(entity, headers);
-    return request;
+    return new HttpEntity<>(entity, headers);
   }
 
   @Sql
@@ -85,6 +85,13 @@ class ConvocatoriaAreaTematicaIT extends BaseIT {
         .isEqualTo(convocatoriaAreaTematicaExistente.getAreaTematica().getId());
     Assertions.assertThat(responseData.getObservaciones()).as("getObservaciones()")
         .isEqualTo(convocatoriaAreaTematica.getObservaciones());
+    Assertions.assertThat(responseData.getCreatedBy()).as("getCreatedBy()").isEqualTo("test-user");
+    Assertions.assertThat(responseData.getCreationDate()).as("getCreationDate()")
+        .isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
+    Assertions.assertThat(responseData.getLastModifiedBy()).as("getLastModifiedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.getLastModifiedDate()).as("getLastModifiedDate()")
+        .isNotNull()
+        .isNotEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
   }
 
   @Sql

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaIT.java
@@ -170,6 +170,10 @@ class ConvocatoriaIT extends BaseIT {
     Assertions.assertThat(responseData.getClasificacionCVN()).as("getClasificacionCVN()")
         .isEqualTo(convocatoria.getClasificacionCVN());
     Assertions.assertThat(responseData.getActivo()).as("getActivo()").isEqualTo(Boolean.TRUE);
+    Assertions.assertThat(responseData.getCreatedBy()).as("getCreatedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.getCreationDate()).as("getCreationDate()").isNotNull();
+    Assertions.assertThat(responseData.getLastModifiedBy()).as("getLastModifiedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.getLastModifiedDate()).as("getLastModifiedDate()").isNotNull();
 
   }
 
@@ -224,6 +228,13 @@ class ConvocatoriaIT extends BaseIT {
     Assertions.assertThat(responseData.getClasificacionCVN()).as("getClasificacionCVN()")
         .isEqualTo(convocatoria.getClasificacionCVN());
     Assertions.assertThat(responseData.getActivo()).as("getActivo()").isEqualTo(convocatoria.getActivo());
+    Assertions.assertThat(responseData.getCreatedBy()).as("getCreatedBy()").isEqualTo("original-user");
+    Assertions.assertThat(responseData.getCreationDate()).as("getCreationDate()")
+        .isEqualTo(Instant.parse("2021-01-01T00:00:00Z"));
+    Assertions.assertThat(responseData.getLastModifiedBy()).as("getLastModifiedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.getLastModifiedDate()).as("getLastModifiedDate()")
+        .isNotNull()
+        .isNotEqualTo(Instant.parse("2021-01-01T00:00:00Z"));
   }
 
   @Sql
@@ -1898,11 +1909,6 @@ class ConvocatoriaIT extends BaseIT {
         .palabraClaveRef(palabraRef)
         .build();
   }
-
-  /**
-   * 
-   * * MOCK
-   */
 
   /**
    * Función que genera Convocatoria

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaPartidaIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaPartidaIT.java
@@ -1,5 +1,6 @@
 package org.crue.hercules.sgi.csp.integration;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -35,9 +36,7 @@ class ConvocatoriaPartidaIT extends BaseIT {
     headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
     headers.set("Authorization", String.format("bearer %s", tokenBuilder.buildToken("user", roles)));
 
-    HttpEntity<ConvocatoriaPartida> request = new HttpEntity<>(entity, headers);
-
-    return request;
+    return new HttpEntity<>(entity, headers);
   }
 
   @Sql(executionPhase = ExecutionPhase.BEFORE_TEST_METHOD, scripts = {
@@ -139,6 +138,13 @@ class ConvocatoriaPartidaIT extends BaseIT {
         .isEqualTo(convocatoriaPartidaToUpdate.getConvocatoriaId());
     Assertions.assertThat(convocatoriaPartidaUpdated.getTipoPartida()).as("getTipoPartida()")
         .isEqualTo(convocatoriaPartidaToUpdate.getTipoPartida());
+    Assertions.assertThat(convocatoriaPartidaUpdated.getCreatedBy()).as("getCreatedBy()").isEqualTo("test-user");
+    Assertions.assertThat(convocatoriaPartidaUpdated.getCreationDate()).as("getCreationDate()")
+        .isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
+    Assertions.assertThat(convocatoriaPartidaUpdated.getLastModifiedBy()).as("getLastModifiedBy()").isEqualTo("user");
+    Assertions.assertThat(convocatoriaPartidaUpdated.getLastModifiedDate()).as("getLastModifiedDate()")
+        .isNotNull()
+        .isNotEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
   }
 
   @Sql(executionPhase = ExecutionPhase.BEFORE_TEST_METHOD, scripts = {
@@ -186,7 +192,7 @@ class ConvocatoriaPartidaIT extends BaseIT {
     Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
-  private ConvocatoriaPartida buildMockConvocatoriaPartida(Long convocatoriaPartidaId) throws Exception {
+  private ConvocatoriaPartida buildMockConvocatoriaPartida(Long convocatoriaPartidaId) {
     Set<ConvocatoriaPartidaDescripcion> descripcionConvocatoriaPartida = new HashSet<>();
     descripcionConvocatoriaPartida.add(new ConvocatoriaPartidaDescripcion(Language.ES, "Test Created Success"));
 

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/service/ConvocatoriaAreaTematicaServiceTest.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/service/ConvocatoriaAreaTematicaServiceTest.java
@@ -1,5 +1,6 @@
 package org.crue.hercules.sgi.csp.service;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +43,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
   private ConvocatoriaAreaTematicaService service;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     service = new ConvocatoriaAreaTematicaServiceImpl(convocatoriaAreaTematicaRepository, areaTematicaRepository,
         convocatoriaService, authorityHelper);
   }
@@ -149,7 +150,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
     // Convocatoria And EntidadRef
     Long convocatoriaId = 1L;
     ConvocatoriaAreaTematica newConvocatoriaAreaTematica = generarConvocatoriaAreaTematica(null, convocatoriaId, 1L);
-    ConvocatoriaAreaTematica ConvocatoriaAreaTematicaExistente = generarConvocatoriaAreaTematica(1L, convocatoriaId,
+    ConvocatoriaAreaTematica convocatoriaAreaTematicaExistente = generarConvocatoriaAreaTematica(1L, convocatoriaId,
         1L);
 
     BDDMockito.given(convocatoriaService.isRegistradaConSolicitudesOProyectos(ArgumentMatchers.<Long>any(),
@@ -158,7 +159,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
         .willReturn(Optional.of(newConvocatoriaAreaTematica.getAreaTematica()));
     BDDMockito.given(convocatoriaAreaTematicaRepository
         .findByConvocatoriaIdAndAreaTematicaId(ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong()))
-        .willReturn(Optional.of(ConvocatoriaAreaTematicaExistente));
+        .willReturn(Optional.of(convocatoriaAreaTematicaExistente));
 
     Assertions.assertThatThrownBy(
         // when: create ConvocatoriaAreaTematica
@@ -191,8 +192,12 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
     // given: existing ConvocatoriaAreaTematica
     ConvocatoriaAreaTematica convocatoriaAreaTematica = generarConvocatoriaAreaTematica(1L, 1L, 1L);
 
+    ConvocatoriaAreaTematica convocatoriaAreaTematicaDb = generarConvocatoriaAreaTematica(1L, 1L, 1L);
+    convocatoriaAreaTematicaDb.setCreatedBy("user-original");
+    convocatoriaAreaTematicaDb.setCreationDate(Instant.parse("2020-01-01T00:00:00Z"));
+
     BDDMockito.given(convocatoriaAreaTematicaRepository.findById(ArgumentMatchers.anyLong()))
-        .willReturn(Optional.of(convocatoriaAreaTematica));
+        .willReturn(Optional.of(convocatoriaAreaTematicaDb));
     BDDMockito.given(convocatoriaAreaTematicaRepository.save(ArgumentMatchers.<ConvocatoriaAreaTematica>any()))
         .willAnswer(new Answer<ConvocatoriaAreaTematica>() {
           @Override
@@ -214,10 +219,12 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
     Assertions.assertThat(updated.getAreaTematica().getId())
         .isEqualTo(convocatoriaAreaTematica.getAreaTematica().getId());
     Assertions.assertThat(updated.getObservaciones()).isEqualTo("observaciones-modificadas");
+    Assertions.assertThat(updated.getCreatedBy()).isEqualTo("user-original");
+    Assertions.assertThat(updated.getCreationDate()).isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
   }
 
   @Test
-  void update_WithNoExistingId_ThrowsNotFoundException() throws Exception {
+  void update_WithNoExistingId_ThrowsNotFoundException() {
     // given: no existing id
     ConvocatoriaAreaTematica convocatoriaAreaTematica = generarConvocatoriaAreaTematica(1L, 1L, 1L);
 
@@ -263,7 +270,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
   }
 
   @Test
-  void delete_WithoutId_ThrowsIllegalArgumentException() throws Exception {
+  void delete_WithoutId_ThrowsIllegalArgumentException() {
     // given: no id
     Long id = null;
 
@@ -276,7 +283,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
   }
 
   @Test
-  void delete_WithNoExistingId_ThrowsNotFoundException() throws Exception {
+  void delete_WithNoExistingId_ThrowsNotFoundException() {
     // given: no existing id
     Long id = 1L;
 
@@ -309,7 +316,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
   }
 
   @Test
-  void findById_WithExistingId_ReturnsConvocatoriaAreaTematica() throws Exception {
+  void findById_WithExistingId_ReturnsConvocatoriaAreaTematica() {
     // given: existing ConvocatoriaAreaTematica
     ConvocatoriaAreaTematica givenConvocatoriaAreaTematica = generarConvocatoriaAreaTematica(1L, 1L, 1L);
 
@@ -332,7 +339,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
   }
 
   @Test
-  void findById_WithNoExistingId_ThrowsNotFoundException() throws Exception {
+  void findById_WithNoExistingId_ThrowsNotFoundException() {
     // given: no existing id
     Long id = 1L;
     BDDMockito.given(convocatoriaAreaTematicaRepository.findById(ArgumentMatchers.anyLong()))
@@ -367,8 +374,7 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
             int toIndex = fromIndex + size;
             toIndex = toIndex > convocatoriasAreasTematicas.size() ? convocatoriasAreasTematicas.size() : toIndex;
             List<ConvocatoriaAreaTematica> content = convocatoriasAreasTematicas.subList(fromIndex, toIndex);
-            Page<ConvocatoriaAreaTematica> page = new PageImpl<>(content, pageable, convocatoriasAreasTematicas.size());
-            return page;
+            return new PageImpl<>(content, pageable, convocatoriasAreasTematicas.size());
           }
         });
 
@@ -382,12 +388,12 @@ class ConvocatoriaAreaTematicaServiceTest extends BaseServiceTest {
     Assertions.assertThat(page.getSize()).as("getSize()").isEqualTo(10);
     Assertions.assertThat(page.getTotalElements()).as("getTotalElements()").isEqualTo(37);
     for (int i = 31; i <= 37; i++) {
-      ConvocatoriaAreaTematica ConvocatoriaAreaTematica = page.getContent()
+      ConvocatoriaAreaTematica convocatoriaAreaTematica = page.getContent()
           .get(i - (page.getSize() * page.getNumber()) - 1);
-      Assertions.assertThat(ConvocatoriaAreaTematica.getId()).isEqualTo(Long.valueOf(i));
-      Assertions.assertThat(ConvocatoriaAreaTematica.getConvocatoriaId()).isEqualTo(convocatoriaId);
-      Assertions.assertThat(ConvocatoriaAreaTematica.getAreaTematica().getId()).isEqualTo(i);
-      Assertions.assertThat(ConvocatoriaAreaTematica.getObservaciones()).isEqualTo("observaciones-" + i);
+      Assertions.assertThat(convocatoriaAreaTematica.getId()).isEqualTo(Long.valueOf(i));
+      Assertions.assertThat(convocatoriaAreaTematica.getConvocatoriaId()).isEqualTo(convocatoriaId);
+      Assertions.assertThat(convocatoriaAreaTematica.getAreaTematica().getId()).isEqualTo(i);
+      Assertions.assertThat(convocatoriaAreaTematica.getObservaciones()).isEqualTo("observaciones-" + i);
     }
   }
 

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/service/ConvocatoriaServiceTest.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/service/ConvocatoriaServiceTest.java
@@ -227,6 +227,114 @@ class ConvocatoriaServiceTest extends BaseServiceTest {
 
   @Test
   @WithMockUser(username = "user", authorities = { "CSP-CON-C" })
+  void create_WithModeloEjecucionWithoutId_NormalizesToNull() {
+    // given: Convocatoria con ModeloEjecucion sin id
+    Set<ConvocatoriaTitulo> convocatoriaTitulo = new HashSet<>();
+    convocatoriaTitulo.add(new ConvocatoriaTitulo(Language.ES, "titulo"));
+
+    Convocatoria convocatoria = Convocatoria.builder()
+        .unidadGestionRef("2")
+        .titulo(convocatoriaTitulo)
+        .modeloEjecucion(new ModeloEjecucion())
+        .build();
+
+    BDDMockito.given(repository.save(ArgumentMatchers.<Convocatoria>any()))
+        .willAnswer(invocation -> {
+          Convocatoria entity = invocation.getArgument(0, Convocatoria.class);
+          entity.setId(1L);
+          return entity;
+        });
+
+    // when: create Convocatoria
+    Convocatoria created = service.create(convocatoria);
+
+    // then: ModeloEjecucion sin id se trata como si se recibe a null
+    Assertions.assertThat(created.getModeloEjecucion()).isNull();
+  }
+
+  @Test
+  @WithMockUser(username = "user", authorities = { "CSP-CON-C" })
+  void create_WithFinalidadWithoutId_NormalizesToNull() {
+    // given: Convocatoria con TipoFinalidad sin id
+    Set<ConvocatoriaTitulo> convocatoriaTitulo = new HashSet<>();
+    convocatoriaTitulo.add(new ConvocatoriaTitulo(Language.ES, "titulo"));
+
+    Convocatoria convocatoria = Convocatoria.builder()
+        .unidadGestionRef("2")
+        .titulo(convocatoriaTitulo)
+        .finalidad(new TipoFinalidad())
+        .build();
+
+    BDDMockito.given(repository.save(ArgumentMatchers.<Convocatoria>any()))
+        .willAnswer(invocation -> {
+          Convocatoria entity = invocation.getArgument(0, Convocatoria.class);
+          entity.setId(1L);
+          return entity;
+        });
+
+    // when: create Convocatoria
+    Convocatoria created = service.create(convocatoria);
+
+    // then: TipoFinalidad sin id se trata como si se recibe a null
+    Assertions.assertThat(created.getFinalidad()).isNull();
+  }
+
+  @Test
+  @WithMockUser(username = "user", authorities = { "CSP-CON-C" })
+  void create_WithRegimenConcurrenciaWithoutId_NormalizesToNull() {
+    // given: Convocatoria con TipoRegimenConcurrencia sin id
+    Set<ConvocatoriaTitulo> convocatoriaTitulo = new HashSet<>();
+    convocatoriaTitulo.add(new ConvocatoriaTitulo(Language.ES, "titulo"));
+
+    Convocatoria convocatoria = Convocatoria.builder()
+        .unidadGestionRef("2")
+        .titulo(convocatoriaTitulo)
+        .regimenConcurrencia(new TipoRegimenConcurrencia())
+        .build();
+
+    BDDMockito.given(repository.save(ArgumentMatchers.<Convocatoria>any()))
+        .willAnswer(invocation -> {
+          Convocatoria entity = invocation.getArgument(0, Convocatoria.class);
+          entity.setId(1L);
+          return entity;
+        });
+
+    // when: create Convocatoria
+    Convocatoria created = service.create(convocatoria);
+
+    // then: TipoRegimenConcurrencia sin id se trata como si se recibe a null
+    Assertions.assertThat(created.getRegimenConcurrencia()).isNull();
+  }
+
+  @Test
+  @WithMockUser(username = "user", authorities = { "CSP-CON-C" })
+  void create_WithAmbitoGeograficoWithoutId_NormalizesToNull() {
+    // given: Convocatoria con TipoAmbitoGeografico sin id
+    Set<ConvocatoriaTitulo> convocatoriaTitulo = new HashSet<>();
+    convocatoriaTitulo.add(new ConvocatoriaTitulo(Language.ES, "titulo"));
+
+    Convocatoria convocatoria = Convocatoria.builder()
+        .unidadGestionRef("2")
+        .titulo(convocatoriaTitulo)
+        .ambitoGeografico(new TipoAmbitoGeografico())
+        .build();
+
+    BDDMockito.given(repository.save(ArgumentMatchers.<Convocatoria>any()))
+        .willAnswer(invocation -> {
+          Convocatoria entity = invocation.getArgument(0, Convocatoria.class);
+          entity.setId(1L);
+          return entity;
+        });
+
+    // when: create Convocatoria
+    Convocatoria created = service.create(convocatoria);
+
+    // then: TipoAmbitoGeografico sin id se trata como si se recibe a null
+    Assertions.assertThat(created.getAmbitoGeografico()).isNull();
+  }
+
+  @Test
+  @WithMockUser(username = "user", authorities = { "CSP-CON-C" })
   void create_WithId_ThrowsIllegalArgumentException() {
     // given: a Convocatoria with id filled
     Convocatoria convocatoria = generarMockConvocatoria(1L, 1L, 1L, 1L, 1L, 1L, Boolean.TRUE);
@@ -574,7 +682,11 @@ class ConvocatoriaServiceTest extends BaseServiceTest {
     Convocatoria convocatoria = generarMockConvocatoria(1L, 1L, 1L, 1L, 1L, 1L, Boolean.TRUE);
     ConfiguracionSolicitud configuracionSolicitud = generarMockConfiguracionSolicitud(1L, convocatoria, 1L);
 
-    BDDMockito.given(repository.findById(ArgumentMatchers.anyLong())).willReturn(Optional.of(convocatoria));
+    Convocatoria convocatoriaDb = generarMockConvocatoria(1L, 1L, 1L, 1L, 1L, 1L, Boolean.TRUE);
+    convocatoriaDb.setCreatedBy("user-original");
+    convocatoriaDb.setCreationDate(Instant.parse("2020-01-01T00:00:00Z"));
+
+    BDDMockito.given(repository.findById(ArgumentMatchers.anyLong())).willReturn(Optional.of(convocatoriaDb));
 
     BDDMockito.given(configuracionSolicitudRepository.findByConvocatoriaId(ArgumentMatchers.anyLong()))
         .willReturn(Optional.of(configuracionSolicitud));
@@ -629,6 +741,8 @@ class ConvocatoriaServiceTest extends BaseServiceTest {
     Assertions.assertThat(updated.getAmbitoGeografico().getId()).isEqualTo(convocatoria.getAmbitoGeografico().getId());
     Assertions.assertThat(updated.getClasificacionCVN()).isEqualTo(convocatoria.getClasificacionCVN());
     Assertions.assertThat(updated.getActivo()).isEqualTo(convocatoria.getActivo());
+    Assertions.assertThat(updated.getCreatedBy()).isEqualTo("user-original");
+    Assertions.assertThat(updated.getCreationDate()).isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
   }
 
   @Test

--- a/sgi-csp-service/src/test/resources/org/crue/hercules/sgi/csp/integration/ConfiguracionSolicitudIT.update_ReturnsConfiguracionSolicitud.sql
+++ b/sgi-csp-service/src/test/resources/org/crue/hercules/sgi/csp/integration/ConfiguracionSolicitudIT.update_ReturnsConfiguracionSolicitud.sql
@@ -67,6 +67,6 @@ INSERT INTO test.convocatoria_fase_observaciones (convocatoria_fase_id, lang, va
 INSERT INTO test.convocatoria_fase_observaciones (convocatoria_fase_id, lang, value_) VALUES (2, 'es', 'observaciones-2');
 
 -- CONFIGURACION SOLICITUD
-INSERT INTO test.configuracion_solicitud 
-(id, convocatoria_id, tramitacion_sgi, convocatoria_fase_id, importe_maximo_solicitud) 
-VALUES(1, 1, TRUE, 1, 12345);
+INSERT INTO test.configuracion_solicitud
+(id, convocatoria_id, tramitacion_sgi, convocatoria_fase_id, importe_maximo_solicitud, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(1, 1, TRUE, 1, 12345, 'original-user', '2021-01-01T00:00:00Z', 'original-user', '2021-01-01T00:00:00Z');

--- a/sgi-csp-service/src/test/resources/org/crue/hercules/sgi/csp/integration/ConvocatoriaAreaTematicaIT.update_ReturnsConvocatoriaAreaTematica.sql
+++ b/sgi-csp-service/src/test/resources/org/crue/hercules/sgi/csp/integration/ConvocatoriaAreaTematicaIT.update_ReturnsConvocatoriaAreaTematica.sql
@@ -31,8 +31,8 @@ INSERT INTO test.tipo_ambito_geografico (id, activo) VALUES (1, true);
 INSERT INTO test.tipo_ambito_geografico_nombre (tipo_ambito_geografico_id, lang, value_) VALUES(1, 'es', 'nombre-001');
 
 -- CONVOCATORIA
-INSERT INTO test.convocatoria (id, unidad_gestion_ref, modelo_ejecucion_id, codigo, fecha_publicacion, fecha_provisional, fecha_concesion, tipo_finalidad_id, tipo_regimen_concurrencia_id, estado, duracion, tipo_ambito_geografico_id, clasificacion_cvn, activo)
-VALUES (1, 'unidad-001', 1, 'codigo-001', '2021-10-15T23:59:59Z', '2021-10-16T23:59:59Z', '2021-10-17T23:59:59Z', 1, 1, 'REGISTRADA', 12, 1, 'AYUDAS', true);
+INSERT INTO test.convocatoria (id, unidad_gestion_ref, modelo_ejecucion_id, codigo, fecha_publicacion, fecha_provisional, fecha_concesion, tipo_finalidad_id, tipo_regimen_concurrencia_id, estado, duracion, tipo_ambito_geografico_id, clasificacion_cvn, activo, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES (1, 'unidad-001', 1, 'codigo-001', '2021-10-15T23:59:59Z', '2021-10-16T23:59:59Z', '2021-10-17T23:59:59Z', 1, 1, 'REGISTRADA', 12, 1, 'AYUDAS', true, 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
 
 -- CONVOCATORIA_TITULO
 INSERT INTO test.convocatoria_titulo (convocatoria_id, lang, value_) VALUES (1, 'es', 'titulo-001');
@@ -64,4 +64,4 @@ INSERT INTO test.area_tematica_descripcion (area_tematica_id, lang, value_) VALU
 
 
 -- CONVOCATORIA AREA TEMATICA
-INSERT INTO test.convocatoria_area_tematica (id, convocatoria_id, area_tematica_id, observaciones) VALUES (1, 1, 2, 'observaciones-001');
+INSERT INTO test.convocatoria_area_tematica (id, convocatoria_id, area_tematica_id, observaciones, created_by, creation_date, last_modified_by, last_modified_date) VALUES (1, 1, 2, 'observaciones-001', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');

--- a/sgi-csp-service/src/test/resources/org/crue/hercules/sgi/csp/integration/ConvocatoriaIT.update_ReturnsConvocatoria.sql
+++ b/sgi-csp-service/src/test/resources/org/crue/hercules/sgi/csp/integration/ConvocatoriaIT.update_ReturnsConvocatoria.sql
@@ -34,8 +34,8 @@ INSERT INTO test.tipo_ambito_geografico (id, activo) VALUES (1, true);
 INSERT INTO test.tipo_ambito_geografico_nombre (tipo_ambito_geografico_id, lang, value_) VALUES(1, 'es', 'nombre-001');
 
 -- CONVOCATORIA
-INSERT INTO test.convocatoria (id, unidad_gestion_ref, modelo_ejecucion_id, codigo, fecha_publicacion, fecha_provisional, fecha_concesion, tipo_finalidad_id, tipo_regimen_concurrencia_id, estado, duracion, tipo_ambito_geografico_id, clasificacion_cvn, activo, formulario_solicitud)
-VALUES (1, '2', 1, 'codigo-001', '2021-10-15T23:59:59Z', '2021-10-16T23:59:59Z', '2021-10-17T23:59:59Z', 1, 1, 'REGISTRADA', 12, 1, 'AYUDAS', true, 'PROYECTO');
+INSERT INTO test.convocatoria (id, unidad_gestion_ref, modelo_ejecucion_id, codigo, fecha_publicacion, fecha_provisional, fecha_concesion, tipo_finalidad_id, tipo_regimen_concurrencia_id, estado, duracion, tipo_ambito_geografico_id, clasificacion_cvn, activo, formulario_solicitud, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES (1, '2', 1, 'codigo-001', '2021-10-15T23:59:59Z', '2021-10-16T23:59:59Z', '2021-10-17T23:59:59Z', 1, 1, 'REGISTRADA', 12, 1, 'AYUDAS', true, 'PROYECTO', 'original-user', '2021-01-01T00:00:00Z', 'original-user', '2021-01-01T00:00:00Z');
 
 -- CONVOCATORIA_TITULO
 INSERT INTO test.convocatoria_titulo (convocatoria_id, lang, value_) VALUES (1, 'es', 'titulo-001');

--- a/sgi-csp-service/src/test/resources/scripts/convocatoria_partida.sql
+++ b/sgi-csp-service/src/test/resources/scripts/convocatoria_partida.sql
@@ -10,14 +10,14 @@
 */
 
 -- CONVOCATORIA_ENLACE
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (1, 'CONV-PART-01', 1, 'GASTO');
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (2, 'CONV-PART-02', 2, 'GASTO');
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (3, 'CONV-PART-03', 3, 'INGRESO');
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (4, 'CONV-PART-04', 4, 'GASTO');
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (5, 'CONV-PART-05', 5, 'GASTO');
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (6, 'CONV-PART-06', 1, 'INGRESO');
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (7, 'CONV-PART-07', 1, 'INGRESO');
-INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida) VALUES (8, 'CONV-PART-08', 1, 'INGRESO');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (1, 'CONV-PART-01', 1, 'GASTO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (2, 'CONV-PART-02', 2, 'GASTO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (3, 'CONV-PART-03', 3, 'INGRESO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (4, 'CONV-PART-04', 4, 'GASTO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (5, 'CONV-PART-05', 5, 'GASTO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (6, 'CONV-PART-06', 1, 'INGRESO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (7, 'CONV-PART-07', 1, 'INGRESO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
+INSERT INTO test.convocatoria_partida (id, codigo, convocatoria_id, tipo_partida, created_by, creation_date, last_modified_by, last_modified_date) VALUES (8, 'CONV-PART-08', 1, 'INGRESO', 'test-user', '2020-01-01 00:00:00', 'test-user', '2020-01-01 00:00:00');
 
 -- CONVOCATORIA_ENLACE_DESCRIPCION
 INSERT INTO test.convocatoria_partida_descripcion (convocatoria_partida_id, lang, value_) VALUES (1, 'es', 'Testing 1');

--- a/sgi-webapp/src/app/module/csp/convocatoria/convocatoria-formulario/convocatoria-datos-generales/convocatoria-datos-generales.component.html
+++ b/sgi-webapp/src/app/module/csp/convocatoria/convocatoria-formulario/convocatoria-datos-generales/convocatoria-datos-generales.component.html
@@ -306,7 +306,7 @@
       </table>
     </div>
     <div class="separation-button">
-      <button color="three" aria-label="Center Align" mat-raised-button (click)="openModal()"
+      <button color="three" mat-raised-button (click)="openModal()"
         *ngIf="convocatoriaAreaTematicas.data.length === 0 && !formPart.isConvocatoriaVinculada && formPart.showAddAreaTematica">
         <mat-icon color="accent">add_circle</mat-icon>
         {{ 'btn.add.entity' | translate:msgParamAreaTematicaEntity }}

--- a/sgi-webapp/src/app/module/csp/convocatoria/convocatoria-formulario/convocatoria-datos-generales/convocatoria-datos-generales.fragment.ts
+++ b/sgi-webapp/src/app/module/csp/convocatoria/convocatoria-formulario/convocatoria-datos-generales/convocatoria-datos-generales.fragment.ts
@@ -21,7 +21,7 @@ import { anioValidator } from '@core/validators/anio-validator';
 import { I18nValidators } from '@core/validators/i18n-validator';
 import { DateTime } from 'luxon';
 import { NGXLogger } from 'ngx-logger';
-import { BehaviorSubject, EMPTY, Observable, Subject, from, merge, of } from 'rxjs';
+import { BehaviorSubject, EMPTY, from, merge, Observable, of, Subject } from 'rxjs';
 import { catchError, map, mergeMap, switchMap, takeLast, tap } from 'rxjs/operators';
 
 export interface AreaTematicaData {
@@ -45,13 +45,13 @@ export class ConvocatoriaDatosGeneralesFragment extends FormFragment<IConvocator
   constructor(
     private readonly logger: NGXLogger,
     key: number,
-    private convocatoriaService: ConvocatoriaService,
-    private proyectoService: ProyectoService,
-    private empresaService: EmpresaService,
-    private convocatoriaEntidadGestoraService: ConvocatoriaEntidadGestoraService,
-    private unidadGestionService: UnidadGestionService,
-    private convocatoriaAreaTematicaService: ConvocatoriaAreaTematicaService,
-    private configuracionSolicitudService: ConfiguracionSolicitudService,
+    private readonly convocatoriaService: ConvocatoriaService,
+    private readonly proyectoService: ProyectoService,
+    private readonly empresaService: EmpresaService,
+    private readonly convocatoriaEntidadGestoraService: ConvocatoriaEntidadGestoraService,
+    private readonly unidadGestionService: UnidadGestionService,
+    private readonly convocatoriaAreaTematicaService: ConvocatoriaAreaTematicaService,
+    private readonly configuracionSolicitudService: ConfiguracionSolicitudService,
     public isConvocatoriaVinculada: boolean,
     public hasEditPerm: boolean,
     private readonly palabraClaveService: PalabraClaveService
@@ -240,33 +240,30 @@ export class ConvocatoriaDatosGeneralesFragment extends FormFragment<IConvocator
   }
 
   private checkIfAddAreaTematicaIsAllowed(): void {
-    const fechaActual = DateTime.now();
-    if (this.isEdit()) {
-      this.configuracionSolicitudService.findByConvocatoriaId(this.getKey() as number).pipe(
-        map(configuracionSolicitud => {
-          if (configuracionSolicitud === null && this.hasEditPerm) {
-            this.showAddAreaTematica = true;
-          }
-          else if (configuracionSolicitud.fasePresentacionSolicitudes === null && this.hasEditPerm) {
-            this.showAddAreaTematica = true;
-          }
-          return configuracionSolicitud?.fasePresentacionSolicitudes?.fechaInicio ?? null;
-        })
-      ).subscribe(fechaInicio => {
-        if ((this.convocatoria.estado === Estado.REGISTRADA || this.convocatoria.estado === Estado.BORRADOR)
-          && (fechaInicio === null || fechaInicio > fechaActual) && this.hasEditPerm) {
-          return this.showAddAreaTematica = true;
-        }
-        return this.showAddAreaTematica = false;
-      });
-    } else {
+    if (!this.isEdit()) {
       this.showAddAreaTematica = true;
+      return;
     }
+
+    const fechaActual = DateTime.now();
+
+    this.subscriptions.push(
+      this.configuracionSolicitudService.findByConvocatoriaId(this.getKey() as number).pipe(
+        map(configuracionSolicitud => configuracionSolicitud?.fasePresentacionSolicitudes?.fechaInicio ?? null)
+      ).subscribe(fechaInicio => {
+        const plazoPresentacionNoIniciado = fechaInicio === null || fechaInicio > fechaActual;
+
+        this.showAddAreaTematica = this.hasEditPerm && (
+          this.convocatoria.estado === Estado.BORRADOR ||
+          (this.convocatoria.estado === Estado.REGISTRADA && plazoPresentacionNoIniciado)
+        );
+      })
+    );
   }
 
   private checkHasProyectoVinculado(key): void {
     this.subscriptions.push(this.proyectoService.findAllProyectosByConvocatoria(key).subscribe(
-      (proyectos) => this.hasProyectoVinculado$.next(Boolean(!!proyectos.total))
+      (proyectos) => this.hasProyectoVinculado$.next(Boolean(proyectos.total))
     ));
   }
 


### PR DESCRIPTION
Los métodos update() pasaban el objeto de entrada directamente a repository.save() en lugar de mutar la entidad gestionada, lo que provocaba que created_by y creation_date se perdieran al guardar.

Entidades corregidas:
- ConfiguracionSolicitud
- Convocatoria
- ConvocatoriaAreaTematica
- ConvocatoriaPartida