### PR TITLE
[#103] [BUG][CSP][PRO] Preservar campos de auditoría al modificar equipo de proyecto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - [CSP][CON] Corregida la pérdida de los campos de auditoría de creación (`created_by`, `creation_date`) al modificar una convocatoria y sus entidades relacionadas ([#103](https://github.com/herculesproject/sgi/issues/103)).
+- [CSP][PRO] Corregida la pérdida de los campos de auditoría (`created_by`, `creation_date`, `last_modified_by`, `last_modified_date`) al modificar el equipo de un proyecto. Además, los miembros sin cambios reales ya no generan un UPDATE innecesario en base de datos ([#72](https://github.com/herculesproject/sgi/issues/72)).
 
 ## 1.1.0 (2026-06-11)
 

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ProyectoEquipoServiceImpl.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/impl/ProyectoEquipoServiceImpl.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.crue.hercules.sgi.csp.config.SgiConfigProperties;
 import org.crue.hercules.sgi.csp.enums.FormularioSolicitud;
@@ -87,119 +86,201 @@ public class ProyectoEquipoServiceImpl implements ProyectoEquipoService {
     Proyecto proyecto = proyectoRepository.findById(proyectoId)
         .orElseThrow(() -> new ProyectoNotFoundException(proyectoId));
 
-    List<ProyectoEquipo> proyectoEquipoesBD = repository.findAllByProyectoId(proyectoId);
+    List<ProyectoEquipo> miembrosEquipoBD = repository.findAllByProyectoId(proyectoId);
 
     // Miembros del equipo eliminados
-    List<ProyectoEquipo> proyectoEquiposEliminar = proyectoEquipoesBD.stream()
-        .filter(periodo -> proyectoEquipos.stream().map(ProyectoEquipo::getId)
-            .noneMatch(id -> Objects.equals(id, periodo.getId())))
-        .collect(Collectors.toList());
+    List<ProyectoEquipo> proyectoEquiposEliminar = miembrosEquipoBD.stream()
+        .filter(bd -> proyectoEquipos.stream()
+            .map(ProyectoEquipo::getId)
+            .noneMatch(id -> Objects.equals(id, bd.getId())))
+        .toList();
 
     if (!proyectoEquiposEliminar.isEmpty()) {
       repository.deleteAll(proyectoEquiposEliminar);
     }
 
-    // Ordena los miembros del equipo por mesInicial
-    List<ProyectoEquipo> proyectoEquipoFechaInicioNull = proyectoEquipos.stream()
-        .filter(periodo -> periodo.getFechaInicio() == null).collect(Collectors.toList());
+    List<ProyectoEquipo> miembrosEquipoSorted = sortMiembrosEquipo(proyectoEquipos);
 
-    List<ProyectoEquipo> proyectoEquipoConFechaInicio = proyectoEquipos.stream()
-        .filter(periodo -> periodo.getFechaInicio() != null).collect(Collectors.toList());
+    List<ProyectoEquipo> proyectoEquipoToSave = new ArrayList<>();
+    List<ProyectoEquipo> returnValue = new ArrayList<>();
 
-    proyectoEquipoFechaInicioNull.sort(Comparator.comparing(ProyectoEquipo::getPersonaRef));
-
-    proyectoEquipoConFechaInicio.sort(Comparator.comparing(ProyectoEquipo::getFechaInicio)
-        .thenComparing(Comparator.comparing(ProyectoEquipo::getPersonaRef)));
-
-    List<ProyectoEquipo> proyectoEquipoAll = new ArrayList<>();
-    proyectoEquipoAll.addAll(proyectoEquipoFechaInicioNull);
-    proyectoEquipoAll.addAll(proyectoEquipoConFechaInicio);
-
-    // Validaciones
     ProyectoEquipo proyectoEquipoAnterior = null;
-    for (ProyectoEquipo proyectoEquipo : proyectoEquipoAll) {
+    for (ProyectoEquipo miembroEquipo : miembrosEquipoSorted) {
 
-      // actualizando
-      if (proyectoEquipo.getId() != null) {
-        ProyectoEquipo proyectoEquipoBD = proyectoEquipoesBD.stream()
-            .filter(periodo -> periodo.getId().equals(proyectoEquipo.getId())).findFirst()
-            .orElseThrow(() -> new ProyectoEquipoNotFoundException(proyectoEquipo.getId()));
+      ProyectoEquipo miembroEquipoBD = miembroEquipo.getId() != null
+          ? miembrosEquipoBD.stream()
+              .filter(p -> p.getId().equals(miembroEquipo.getId())).findFirst()
+              .orElseThrow(() -> new ProyectoEquipoNotFoundException(miembroEquipo.getId()))
+          : null;
 
-        Assert.isTrue(proyectoEquipoBD.getProyectoId().equals(proyectoEquipo.getProyectoId()),
-            () -> ProblemMessage.builder()
-                .key(MSG_PROBLEM_ACCION_DENEGADA)
-                .parameter(MSG_KEY_FIELD, ApplicationContextSupport.getMessage(
-                    MSG_MODEL_PROYECTO))
-                .parameter(MSG_KEY_ENTITY, ApplicationContextSupport.getMessage(
-                    MSG_MODEL_PROYECTO_EQUIPO))
-                .parameter(MSG_KEY_ACTION, ApplicationContextSupport.getMessage(MSG_FIELD_ACTION_MODIFICAR))
-                .build());
+      validateMiembroEquipo(miembroEquipo, miembroEquipoBD, proyectoEquipoAnterior, proyecto);
+
+      miembroEquipo.setProyectoId(proyectoId);
+
+      if (miembroEquipoBD != null) {
+        if (hasEditableFieldsChanged(miembroEquipoBD, miembroEquipo)) {
+          miembroEquipoBD.setPersonaRef(miembroEquipo.getPersonaRef());
+          miembroEquipoBD.setRolProyecto(miembroEquipo.getRolProyecto());
+          miembroEquipoBD.setFechaInicio(miembroEquipo.getFechaInicio());
+          miembroEquipoBD.setFechaFin(miembroEquipo.getFechaFin());
+          proyectoEquipoToSave.add(miembroEquipoBD);
+        }
+
+        returnValue.add(miembroEquipoBD);
+      } else {
+        proyectoEquipoToSave.add(miembroEquipo);
+        returnValue.add(miembroEquipo);
       }
 
-      proyectoEquipo.setProyectoId(proyectoId);
-
-      if (proyectoEquipo.getFechaInicio() != null && proyectoEquipo.getFechaFin() != null) {
-        Assert.isTrue(proyectoEquipo.getFechaInicio().isBefore(proyectoEquipo.getFechaFin()),
-            ApplicationContextSupport.getMessage(MSG_PROYECTO_EQUIPO_FECHA_FIN_ANTERIOR_A_FECHA_INICIO));
-      }
-      if (proyectoEquipo.getFechaInicio() != null && proyecto.getFechaInicio() != null) {
-        Assert.isTrue(
-            (proyectoEquipo.getFechaInicio().isAfter(proyecto.getFechaInicio())
-                || proyectoEquipo.getFechaInicio().equals(proyecto.getFechaInicio())),
-            ApplicationContextSupport.getMessage(MSG_FECHAS_PROYECTO_EQUIPO));
-      }
-
-      Instant proyectoFechaFin = proyecto.getFechaFinDefinitiva() != null ? proyecto.getFechaFinDefinitiva()
-          : proyecto.getFechaFin();
-      if (proyectoEquipo.getFechaFin() != null && proyectoFechaFin != null) {
-        Assert.isTrue(
-            (proyectoEquipo.getFechaFin().isBefore(proyectoFechaFin)
-                || proyectoEquipo.getFechaFin().equals(proyectoFechaFin)),
-            ApplicationContextSupport.getMessage(MSG_FECHAS_PROYECTO_EQUIPO));
-      }
-
-      Specification<ProyectoEquipo> specByProyectoId = ProyectoEquipoSpecifications
-          .byProyectoId(proyectoEquipo.getProyectoId());
-
-      Specification<ProyectoEquipo> specByIdNotEqual = ProyectoEquipoSpecifications
-          .byIdNotEqual(proyectoEquipo.getId());
-
-      Specification<ProyectoEquipo> specByRangoFechaSolapados = ProyectoEquipoSpecifications
-          .byRangoFechaSolapados(proyectoEquipo.getFechaInicio(), proyectoEquipo.getFechaFin());
-
-      Specification<ProyectoEquipo> specByPersonaRef = ProyectoEquipoSpecifications
-          .byPersonaRef(proyectoEquipo.getPersonaRef());
-
-      Specification<ProyectoEquipo> specs = Specification.where(specByProyectoId).and(specByRangoFechaSolapados)
-          .and(specByRangoFechaSolapados).and(specByPersonaRef).and(specByIdNotEqual);
-
-      if (proyectoEquipoAnterior != null
-          && proyectoEquipoAnterior.getPersonaRef().equals(proyectoEquipo.getPersonaRef())) {
-        Assert.isTrue(
-            (repository.count(specs) == 0) && proyectoEquipoAnterior.getFechaFin() != null
-                && proyectoEquipoAnterior.getFechaFin().isBefore(proyectoEquipo.getFechaInicio()),
-            ApplicationContextSupport.getMessage(MSG_PROYECTO_EQUIPO_OVERLOAP));
-      }
-
-      proyectoEquipoAnterior = proyectoEquipo;
+      proyectoEquipoAnterior = miembroEquipo;
 
     }
 
-    if (proyecto.getSolicitudId() != null && proyecto.getEstado().getEstado().equals(Estado.CONCEDIDO)) {
-      Solicitud solicitud = solicitudRepository.findById(proyecto.getSolicitudId())
-          .orElseThrow(() -> new SolicitudNotFoundException(proyecto.getSolicitudId()));
+    validateInvestigadorPrincipal(proyecto, miembrosEquipoSorted);
 
-      if (solicitud.getFormularioSolicitud().equals(FormularioSolicitud.PROYECTO)
-          && proyectoEquipoAll.stream().map(ProyectoEquipo::getPersonaRef)
-              .noneMatch(personaRef -> personaRef.equals(solicitud.getSolicitanteRef()))) {
-        throw new MissingInvestigadorPrincipalInProyectoEquipoException();
-      }
+    if (!proyectoEquipoToSave.isEmpty()) {
+      repository.saveAll(proyectoEquipoToSave);
     }
 
-    List<ProyectoEquipo> returnValue = repository.saveAll(proyectoEquipoAll);
     log.debug("updateProyectoEquiposConvocatoria(Long proyectoId, List<ProyectoEquipo> proyectoEquipos) - end");
 
     return returnValue;
+  }
+
+  /**
+   * Ordena los {@link ProyectoEquipo} para que la validación de solapamientos
+   * pueda hacerse comparando elementos consecutivos.
+   *
+   * Los miembros sin {@code fechaInicio} se colocan primero, ordenados por
+   * {@code personaRef}. El resto se ordenan por {@code fechaInicio} y, en caso
+   * de empate, por {@code personaRef}.
+   *
+   * @param miembros lista de miembros a ordenar.
+   * @return nueva lista ordenada.
+   */
+  private List<ProyectoEquipo> sortMiembrosEquipo(List<ProyectoEquipo> miembros) {
+    List<ProyectoEquipo> sinFecha = miembros.stream()
+        .filter(m -> m.getFechaInicio() == null)
+        .sorted(Comparator.comparing(ProyectoEquipo::getPersonaRef))
+        .toList();
+
+    List<ProyectoEquipo> conFecha = miembros.stream()
+        .filter(m -> m.getFechaInicio() != null)
+        .sorted(Comparator.comparing(ProyectoEquipo::getFechaInicio)
+            .thenComparing(ProyectoEquipo::getPersonaRef))
+        .toList();
+
+    List<ProyectoEquipo> resultado = new ArrayList<>(sinFecha);
+    resultado.addAll(conFecha);
+
+    return resultado;
+  }
+
+  /**
+   * Verifica que el solicitante del proyecto figure en el equipo cuando el
+   * {@link Proyecto} ha sido concedido a partir de una {@link Solicitud} de tipo
+   * {@link FormularioSolicitud#PROYECTO}.
+   *
+   * @param proyecto proyecto a comprobar.
+   * @param miembros lista de miembros del equipo tras la actualización.
+   * @throws MissingInvestigadorPrincipalInProyectoEquipoException si el
+   *                                                               solicitante no
+   *                                                               está en el
+   *                                                               equipo.
+   */
+  private void validateInvestigadorPrincipal(Proyecto proyecto, List<ProyectoEquipo> miembros) {
+    if (proyecto.getSolicitudId() == null || !proyecto.getEstado().getEstado().equals(Estado.CONCEDIDO)) {
+      return;
+    }
+
+    Solicitud solicitud = solicitudRepository.findById(proyecto.getSolicitudId())
+        .orElseThrow(() -> new SolicitudNotFoundException(proyecto.getSolicitudId()));
+
+    if (solicitud.getFormularioSolicitud().equals(FormularioSolicitud.PROYECTO)
+        && miembros.stream().map(ProyectoEquipo::getPersonaRef)
+            .noneMatch(ref -> ref.equals(solicitud.getSolicitanteRef()))) {
+      throw new MissingInvestigadorPrincipalInProyectoEquipoException();
+    }
+  }
+
+  /**
+   * Valida un {@link ProyectoEquipo}.
+   *
+   * <ul>
+   * <li>Si el miembro ya existe en base de datos, verifica que el
+   * {@link Proyecto} al que pertenece no haya cambiado.</li>
+   * <li>Verifica que {@code fechaInicio} sea anterior a {@code fechaFin}.</li>
+   * <li>Verifica que las fechas del miembro estén dentro del rango del
+   * {@link Proyecto}.</li>
+   * <li>Verifica que no haya solapamiento de fechas con el miembro anterior de
+   * la misma persona (la lista de entrada debe estar ordenada por
+   * {@code personaRef} y {@code fechaInicio}).</li>
+   * </ul>
+   *
+   * @param miembroEquipo         datos de entrada del miembro a validar.
+   * @param miembroEquipoBD       entidad recuperada de base de datos,
+   *                              o {@code null} si el miembro es nuevo.
+   * @param miembroEquipoAnterior miembro procesado inmediatamente antes en la
+   *                              lista ordenada, o {@code null} si es el primero.
+   * @param proyecto              proyecto al que pertenece el equipo.
+   */
+  private void validateMiembroEquipo(ProyectoEquipo miembroEquipo, ProyectoEquipo miembroEquipoBD,
+      ProyectoEquipo miembroEquipoAnterior, Proyecto proyecto) {
+
+    if (miembroEquipoBD != null) {
+      Assert.isTrue(miembroEquipoBD.getProyectoId().equals(miembroEquipo.getProyectoId()),
+          () -> ProblemMessage.builder()
+              .key(MSG_PROBLEM_ACCION_DENEGADA)
+              .parameter(MSG_KEY_FIELD, ApplicationContextSupport.getMessage(MSG_MODEL_PROYECTO))
+              .parameter(MSG_KEY_ENTITY, ApplicationContextSupport.getMessage(MSG_MODEL_PROYECTO_EQUIPO))
+              .parameter(MSG_KEY_ACTION, ApplicationContextSupport.getMessage(MSG_FIELD_ACTION_MODIFICAR))
+              .build());
+    }
+
+    if (miembroEquipo.getFechaInicio() != null && miembroEquipo.getFechaFin() != null) {
+      Assert.isTrue(miembroEquipo.getFechaInicio().isBefore(miembroEquipo.getFechaFin()),
+          ApplicationContextSupport.getMessage(MSG_PROYECTO_EQUIPO_FECHA_FIN_ANTERIOR_A_FECHA_INICIO));
+    }
+
+    if (miembroEquipo.getFechaInicio() != null && proyecto.getFechaInicio() != null) {
+      Assert.isTrue(
+          (miembroEquipo.getFechaInicio().isAfter(proyecto.getFechaInicio())
+              || miembroEquipo.getFechaInicio().equals(proyecto.getFechaInicio())),
+          ApplicationContextSupport.getMessage(MSG_FECHAS_PROYECTO_EQUIPO));
+    }
+
+    Instant proyectoFechaFin = proyecto.getFechaFinDefinitiva() != null ? proyecto.getFechaFinDefinitiva()
+        : proyecto.getFechaFin();
+    if (miembroEquipo.getFechaFin() != null && proyectoFechaFin != null) {
+      Assert.isTrue(
+          (miembroEquipo.getFechaFin().isBefore(proyectoFechaFin)
+              || miembroEquipo.getFechaFin().equals(proyectoFechaFin)),
+          ApplicationContextSupport.getMessage(MSG_FECHAS_PROYECTO_EQUIPO));
+    }
+
+    if (miembroEquipoAnterior != null
+        && miembroEquipoAnterior.getPersonaRef().equals(miembroEquipo.getPersonaRef())) {
+      Assert.isTrue(miembroEquipoAnterior.getFechaFin() != null
+          && miembroEquipoAnterior.getFechaFin().isBefore(miembroEquipo.getFechaInicio()),
+          ApplicationContextSupport.getMessage(MSG_PROYECTO_EQUIPO_OVERLOAP));
+    }
+  }
+
+  /**
+   * Indica si dos {@link ProyectoEquipo} difieren en alguno de sus campos
+   * editables.
+   *
+   * @param miembroA primer miembro a comparar.
+   * @param miembroB segundo miembro a comparar.
+   * @return {@code true} si al menos un campo es distinto.
+   */
+  private boolean hasEditableFieldsChanged(ProyectoEquipo miembroA, ProyectoEquipo miembroB) {
+    Long rolMiembroA = miembroA.getRolProyecto() == null ? null : miembroA.getRolProyecto().getId();
+    Long rolMiembroB = miembroB.getRolProyecto() == null ? null : miembroB.getRolProyecto().getId();
+    return !Objects.equals(miembroA.getPersonaRef(), miembroB.getPersonaRef())
+        || !Objects.equals(rolMiembroA, rolMiembroB)
+        || !Objects.equals(miembroA.getFechaInicio(), miembroB.getFechaInicio())
+        || !Objects.equals(miembroA.getFechaFin(), miembroB.getFechaFin());
   }
 
   /**

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ProyectoEquipoIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ProyectoEquipoIT.java
@@ -37,8 +37,7 @@ class ProyectoEquipoIT extends BaseIT {
     headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
     headers.set("Authorization", String.format("bearer %s", tokenBuilder.buildToken("user", "AUTH")));
 
-    HttpEntity<ProyectoEquipo> request = new HttpEntity<>(entity, headers);
-    return request;
+    return new HttpEntity<>(entity, headers);
   }
 
   private HttpEntity<List<ProyectoEquipo>> buildRequestList(HttpHeaders headers, List<ProyectoEquipo> entity)
@@ -48,17 +47,18 @@ class ProyectoEquipoIT extends BaseIT {
     headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
     headers.set("Authorization", String.format("bearer %s", tokenBuilder.buildToken("user", "AUTH", "CSP-PRO-E")));
 
-    HttpEntity<List<ProyectoEquipo>> request = new HttpEntity<>(entity, headers);
-    return request;
+    return new HttpEntity<>(entity, headers);
   }
 
   @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = { "classpath:scripts/modelo_ejecucion.sql",
-      "classpath:scripts/modelo_unidad.sql", "classpath:scripts/tipo_finalidad.sql",
+      "classpath:scripts/modelo_unidad.sql",
+      "classpath:scripts/tipo_finalidad.sql",
       "classpath:scripts/tipo_ambito_geografico.sql",
       "classpath:scripts/tipo_regimen_concurrencia.sql",
       "classpath:scripts/convocatoria.sql",
       "classpath:scripts/proyecto.sql",
-      "classpath:scripts/estado_proyecto.sql", "classpath:scripts/rol_proyecto.sql",
+      "classpath:scripts/estado_proyecto.sql",
+      "classpath:scripts/rol_proyecto.sql",
       "classpath:scripts/proyecto_equipo.sql" })
   @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:cleanup.sql")
   @Test
@@ -125,7 +125,7 @@ class ProyectoEquipoIT extends BaseIT {
 
     Assertions.assertThat(responseFindAllProyectoEquipo.getStatusCode()).isEqualTo(HttpStatus.OK);
     final List<ProyectoEquipo> responseDataFindAll = responseFindAllProyectoEquipo.getBody();
-    Assertions.assertThat(responseDataFindAll.size()).as("size()").isEqualTo(proyectoEquipos.size());
+    Assertions.assertThat(responseDataFindAll).as("size()").hasSize(proyectoEquipos.size());
     Assertions.assertThat(responseDataFindAll.get(0).getId()).as("responseDataFindAll.get(0).getId()")
         .isEqualTo(responseData.get(0).getId());
     Assertions.assertThat(responseDataFindAll.get(1).getId()).as("responseDataFindAll.get(1).getId()")
@@ -158,9 +158,90 @@ class ProyectoEquipoIT extends BaseIT {
     Assertions.assertThat(responseData.getFechaFin()).as("getFechaFin()").isEqualTo("2020-01-15T23:59:59Z");
   }
 
+  @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = { "classpath:scripts/modelo_ejecucion.sql",
+      "classpath:scripts/modelo_unidad.sql",
+      "classpath:scripts/tipo_finalidad.sql",
+      "classpath:scripts/tipo_ambito_geografico.sql",
+      "classpath:scripts/tipo_regimen_concurrencia.sql",
+      "classpath:scripts/convocatoria.sql",
+      "classpath:scripts/proyecto.sql",
+      "classpath:scripts/estado_proyecto.sql",
+      "classpath:scripts/rol_proyecto.sql",
+      "classpath:scripts/proyecto_equipo.sql" })
+  @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:cleanup.sql")
+  @Test
+  void update_WithChanges_PreservaCamposAuditoria() throws Exception {
+    // given: un ProyectoEquipo existente con campos de auditoría de creación y
+    // una modificación en la fecha de fin
+    Long proyectoId = 1L;
+    ProyectoEquipo proyectoEquipoActualizar = generarMockProyectoEquipo(106L, Instant.parse("2020-03-01T00:00:00Z"),
+        Instant.parse("2020-03-15T23:59:59Z"), proyectoId);
+
+    URI uri = UriComponentsBuilder.fromUriString(CONTROLLER_BASE_PATH + PATH_PARAMETER_ID)
+        .buildAndExpand(proyectoId).toUri();
+
+    // when: PATCH con fechaFin modificada
+    final ResponseEntity<List<ProyectoEquipo>> response = restTemplate.exchange(uri, HttpMethod.PATCH,
+        buildRequestList(null, Arrays.asList(proyectoEquipoActualizar)),
+        new ParameterizedTypeReference<List<ProyectoEquipo>>() {
+        });
+
+    // then: se aplica el cambio y se preservan los campos de auditoría de creación
+    Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    List<ProyectoEquipo> responseData = response.getBody();
+    Assertions.assertThat(responseData).hasSize(1);
+    Assertions.assertThat(responseData.get(0).getFechaFin()).as("getFechaFin()")
+        .isEqualTo(Instant.parse("2020-03-15T23:59:59Z"));
+    Assertions.assertThat(responseData.get(0).getCreatedBy()).as("getCreatedBy()").isEqualTo("test-user");
+    Assertions.assertThat(responseData.get(0).getCreationDate()).as("getCreationDate()")
+        .isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
+    Assertions.assertThat(responseData.get(0).getLastModifiedBy()).as("getLastModifiedBy()").isEqualTo("user");
+    Assertions.assertThat(responseData.get(0).getLastModifiedDate()).as("getLastModifiedDate()")
+        .isNotNull()
+        .isNotEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
+  }
+
+  @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = { "classpath:scripts/modelo_ejecucion.sql",
+      "classpath:scripts/modelo_unidad.sql",
+      "classpath:scripts/tipo_finalidad.sql",
+      "classpath:scripts/tipo_ambito_geografico.sql",
+      "classpath:scripts/tipo_regimen_concurrencia.sql",
+      "classpath:scripts/convocatoria.sql",
+      "classpath:scripts/proyecto.sql",
+      "classpath:scripts/estado_proyecto.sql",
+      "classpath:scripts/rol_proyecto.sql",
+      "classpath:scripts/proyecto_equipo.sql" })
+  @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:cleanup.sql")
+  @Test
+  void update_WithoutChanges_NoActualizaCamposAuditoria() throws Exception {
+    // given: un ProyectoEquipo existente sin cambios
+    Long proyectoId = 1L;
+    ProyectoEquipo proyectoEquipoSinCambios = generarMockProyectoEquipo(106L, Instant.parse("2020-03-01T00:00:00Z"),
+        Instant.parse("2020-03-31T23:59:59Z"), proyectoId);
+
+    URI uri = UriComponentsBuilder.fromUriString(CONTROLLER_BASE_PATH + PATH_PARAMETER_ID)
+        .buildAndExpand(proyectoId).toUri();
+
+    // when: PATCH con datos idénticos a los existentes en BD
+    final ResponseEntity<List<ProyectoEquipo>> response = restTemplate.exchange(uri, HttpMethod.PATCH,
+        buildRequestList(null, Arrays.asList(proyectoEquipoSinCambios)),
+        new ParameterizedTypeReference<List<ProyectoEquipo>>() {
+        });
+
+    // then: se devuelve la entidad sin modificar
+    Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    List<ProyectoEquipo> responseData = response.getBody();
+    Assertions.assertThat(responseData).hasSize(1);
+    Assertions.assertThat(responseData.get(0).getCreatedBy()).as("getCreatedBy()").isEqualTo("test-user");
+    Assertions.assertThat(responseData.get(0).getCreationDate()).as("getCreationDate()")
+        .isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
+    Assertions.assertThat(responseData.get(0).getLastModifiedDate()).as("getLastModifiedDate() no debe cambiar")
+        .isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
+  }
+
   /**
    * Función que devuelve un objeto ProyectoEquipo
-   * 
+   *
    * @param id         id del ProyectoEquipo
    * @param mesInicial Mes inicial
    * @param mesFinal   Mes final
@@ -169,12 +250,14 @@ class ProyectoEquipoIT extends BaseIT {
    */
   private ProyectoEquipo generarMockProyectoEquipo(Long id, Instant fechaInicio, Instant fechaFin, Long proyectoId) {
 
-    ProyectoEquipo proyectoEquipo = ProyectoEquipo.builder().id(id).proyectoId(proyectoId)
-        .rolProyecto(RolProyecto.builder().id(1L).build()).fechaInicio(fechaInicio).fechaFin(fechaFin).personaRef("001")
+    return ProyectoEquipo.builder()
+        .id(id)
+        .proyectoId(proyectoId)
+        .rolProyecto(RolProyecto.builder().id(1L).build())
+        .fechaInicio(fechaInicio)
+        .fechaFin(fechaFin)
+        .personaRef("001")
         .build();
-
-    return proyectoEquipo;
-
   }
 
 }

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ProyectoIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ProyectoIT.java
@@ -1108,7 +1108,7 @@ class ProyectoIT extends BaseIT {
     headers.add("X-Page", "0");
     headers.add("X-Page-Size", "10");
     String sort = "id,desc";
-    String filter = "personaRef=ke=00";
+    String filter = "personaRef=ke=ref-00";
 
     Long proyectoId = 1L;
 
@@ -3287,7 +3287,7 @@ class ProyectoIT extends BaseIT {
     Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     List<ProyectoEquipoDto> equipo = response.getBody();
     Integer numPersonasEquipo = equipo.size();
-    Assertions.assertThat(numPersonasEquipo).isEqualTo(5);
+    Assertions.assertThat(numPersonasEquipo).isEqualTo(6);
   }
 
   @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/service/ProyectoEquipoServiceTest.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/service/ProyectoEquipoServiceTest.java
@@ -29,6 +29,7 @@ import org.crue.hercules.sgi.csp.util.ProyectoHelper;
 import org.crue.hercules.sgi.framework.i18n.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.BDDMockito;
 import org.mockito.Mock;
@@ -139,6 +140,77 @@ class ProyectoEquipoServiceTest extends BaseServiceTest {
 
     Mockito.verify(repository, Mockito.times(1)).deleteAll(ArgumentMatchers.<ProyectoEquipo>anyList());
     Mockito.verify(repository, Mockito.times(1)).saveAll(ArgumentMatchers.<ProyectoEquipo>anyList());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void update_ExistingProyectoEquipo_PreservaCamposAuditoria() {
+    // given: un ProyectoEquipo existente con campos de auditoría de creación y
+    // unos datos de actualización (con una fecha distinta) que no los incluyen
+    Long proyectoId = 1L;
+    Proyecto proyecto = generarMockProyecto(proyectoId);
+
+    ProyectoEquipo proyectoEquipoBD = generarMockProyectoEquipo(4L, Instant.parse("2020-03-16T00:00:00Z"),
+        Instant.parse("2020-04-15T23:59:59Z"), proyectoId);
+    proyectoEquipoBD.setCreatedBy("user-original");
+    proyectoEquipoBD.setCreationDate(Instant.parse("2020-01-01T00:00:00Z"));
+
+    List<ProyectoEquipo> proyectoEquipoExistentes = new ArrayList<>();
+    proyectoEquipoExistentes.add(proyectoEquipoBD);
+
+    ProyectoEquipo proyectoEquipoActualizar = generarMockProyectoEquipo(4L, Instant.parse("2020-03-16T00:00:00Z"),
+        Instant.parse("2020-04-14T23:59:59Z"), proyectoId);
+
+    BDDMockito.given(proyectoRepository.findById(ArgumentMatchers.anyLong())).willReturn(Optional.of(proyecto));
+    BDDMockito.given(repository.findAllByProyectoId(ArgumentMatchers.anyLong())).willReturn(proyectoEquipoExistentes);
+    BDDMockito.given(repository.saveAll(ArgumentMatchers.<ProyectoEquipo>anyList()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // when: update ProyectoEquipo
+    List<ProyectoEquipo> result = service.update(proyectoId, Arrays.asList(proyectoEquipoActualizar));
+
+    // then: se actualiza y se conservan los campos de auditoría de la creación
+    Assertions.assertThat(result).hasSize(1);
+    Assertions.assertThat(result.get(0).getCreatedBy()).as("createdBy").isEqualTo("user-original");
+    Assertions.assertThat(result.get(0).getCreationDate()).as("creationDate")
+        .isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
+    Assertions.assertThat(result.get(0).getFechaFin()).as("fechaFin")
+        .isEqualTo(Instant.parse("2020-04-14T23:59:59Z"));
+
+    ArgumentCaptor<List<ProyectoEquipo>> captor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(repository, Mockito.times(1)).saveAll(captor.capture());
+    Assertions.assertThat(captor.getValue()).hasSize(1);
+    Assertions.assertThat(captor.getValue().get(0)).as("se persiste la entidad gestionada")
+        .isSameAs(proyectoEquipoBD);
+  }
+
+  @Test
+  void update_ExistingProyectoEquipoSinCambios_NoEjecutaSave() {
+    // given: un ProyectoEquipo existente sin cambios
+    Long proyectoId = 1L;
+    Proyecto proyecto = generarMockProyecto(proyectoId);
+
+    ProyectoEquipo proyectoEquipoBD = generarMockProyectoEquipo(4L, Instant.parse("2020-03-16T00:00:00Z"),
+        Instant.parse("2020-04-15T23:59:59Z"), proyectoId);
+    proyectoEquipoBD.setCreatedBy("user-original");
+    proyectoEquipoBD.setCreationDate(Instant.parse("2020-01-01T00:00:00Z"));
+
+    List<ProyectoEquipo> proyectoEquipoExistentes = new ArrayList<>();
+    proyectoEquipoExistentes.add(proyectoEquipoBD);
+
+    ProyectoEquipo proyectoEquipoSinCambios = generarMockProyectoEquipo(4L, Instant.parse("2020-03-16T00:00:00Z"),
+        Instant.parse("2020-04-15T23:59:59Z"), proyectoId);
+
+    BDDMockito.given(proyectoRepository.findById(ArgumentMatchers.anyLong())).willReturn(Optional.of(proyecto));
+    BDDMockito.given(repository.findAllByProyectoId(ArgumentMatchers.anyLong())).willReturn(proyectoEquipoExistentes);
+
+    // when: update ProyectoEquipo
+    List<ProyectoEquipo> result = service.update(proyectoId, Arrays.asList(proyectoEquipoSinCambios));
+
+    // then: se devuelve la entidad sin modificar
+    Mockito.verify(repository, Mockito.never()).saveAll(ArgumentMatchers.<ProyectoEquipo>anyList());
+    Assertions.assertThat(result).hasSize(1);
+    Assertions.assertThat(result.get(0)).isSameAs(proyectoEquipoBD);
   }
 
   @Test

--- a/sgi-csp-service/src/test/resources/scripts/proyecto_equipo.sql
+++ b/sgi-csp-service/src/test/resources/scripts/proyecto_equipo.sql
@@ -1,36 +1,40 @@
--- DEPENDENCIAS: proyecto 
+-- DEPENDENCIAS: proyecto
 /*
-  scripts = { 
+  scripts = {
     "classpath:scripts/modelo_ejecucion.sql",
     "classpath:scripts/modelo_unidad.sql",
     "classpath:scripts/tipo_finalidad.sql",
     "classpath:scripts/tipo_ambito_geografico.sql",
-    "classpath:scripts/estado_proyecto.sql",    
+    "classpath:scripts/estado_proyecto.sql",
     "classpath:scripts/proyecto.sql",
      "classpath:scripts/rol_proyecto.sql"
   }
 */
 
 INSERT INTO test.proyecto_equipo
-(id, proyecto_id, fecha_inicio, fecha_fin, persona_ref, horas_dedicacion, rol_proyecto_id)
-VALUES(100, 1, '2020-01-01T00:00:00Z', '2020-01-15T23:59:59Z', 'ref-001', 1, 1);
+(id, proyecto_id, persona_ref, rol_proyecto_id, fecha_inicio, fecha_fin, horas_dedicacion, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(100, 1, 'ref-001', 1, '2020-01-01T00:00:00Z', '2020-01-15T23:59:59Z', 1, 'admin', '2020-01-01T00:00:00Z', 'admin', '2020-01-01T00:00:00Z');
 
 INSERT INTO test.proyecto_equipo
-(id, proyecto_id, fecha_inicio, fecha_fin, persona_ref, horas_dedicacion, rol_proyecto_id)
-VALUES(101, 1, '2020-02-01T00:00:00Z', '2020-02-15T23:59:59Z', 'ref-002', 2, 1);
+(id, proyecto_id, persona_ref, rol_proyecto_id, fecha_inicio, fecha_fin, horas_dedicacion, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(101, 1, 'ref-002', 1, '2020-02-01T00:00:00Z', '2020-02-15T23:59:59Z', 2, 'admin', '2020-01-01T00:00:00Z', 'admin', '2020-01-01T00:00:00Z');
 
 INSERT INTO test.proyecto_equipo
-(id, proyecto_id, fecha_inicio, fecha_fin, persona_ref, horas_dedicacion, rol_proyecto_id)
-VALUES(102, 2, '2020-03-01T00:00:00Z', '2020-03-15T23:59:59Z', 'ref-003', 3, 1);
+(id, proyecto_id, persona_ref, rol_proyecto_id, fecha_inicio, fecha_fin, horas_dedicacion, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(102, 2, 'ref-003', 1, '2020-03-01T00:00:00Z', '2020-03-15T23:59:59Z', 3, 'admin', '2020-01-01T00:00:00Z', 'admin', '2020-01-01T00:00:00Z');
 
 INSERT INTO test.proyecto_equipo
-(id, proyecto_id, fecha_inicio, fecha_fin, persona_ref, horas_dedicacion, rol_proyecto_id)
-VALUES(103, 1, '2020-04-01T00:00:00Z', '2020-04-15T23:59:59Z', 'ref-004', 4, 1);
+(id, proyecto_id, persona_ref, rol_proyecto_id, fecha_inicio, fecha_fin, horas_dedicacion, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(103, 1, 'ref-004', 1, '2020-04-01T00:00:00Z', '2020-04-15T23:59:59Z', 4, 'admin', '2020-01-01T00:00:00Z', 'admin', '2020-01-01T00:00:00Z');
 
 INSERT INTO test.proyecto_equipo
-(id, proyecto_id, fecha_inicio, fecha_fin, persona_ref, horas_dedicacion, rol_proyecto_id)
-VALUES(104, 1, '2020-05-01T00:00:00Z', '2020-05-15T23:59:59Z', 'ref-5', 5, 1);
+(id, proyecto_id, persona_ref, rol_proyecto_id, fecha_inicio, fecha_fin, horas_dedicacion, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(104, 1, 'ref-5', 1, '2020-05-01T00:00:00Z', '2020-05-15T23:59:59Z', 5, 'admin', '2020-01-01T00:00:00Z', 'admin', '2020-01-01T00:00:00Z');
 
 INSERT INTO test.proyecto_equipo
-(id, proyecto_id, fecha_inicio, fecha_fin, persona_ref, horas_dedicacion, rol_proyecto_id)
-VALUES(105, 1, '2021-05-01T00:00:00Z', '2022-05-15T23:59:59Z', 'ref-6', 6, 1);
+(id, proyecto_id, persona_ref, rol_proyecto_id, fecha_inicio, fecha_fin, horas_dedicacion, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(105, 1, 'ref-6', 1, '2021-05-01T00:00:00Z', '2022-05-15T23:59:59Z', 6, 'admin', '2020-01-01T00:00:00Z', 'admin', '2020-01-01T00:00:00Z');
+
+INSERT INTO test.proyecto_equipo
+(id, proyecto_id, persona_ref, rol_proyecto_id, fecha_inicio, fecha_fin, horas_dedicacion, created_by, creation_date, last_modified_by, last_modified_date)
+VALUES(106, 1, '001', 1, '2020-03-01T00:00:00Z', '2020-03-31T23:59:59Z', null, 'test-user', '2020-01-01T00:00:00Z', 'test-user', '2020-01-01T00:00:00Z');


### PR DESCRIPTION
El método update() pasaba los objetos de entrada directamente a repository.saveAll() en lugar de mutar la entidad de BD, lo que provocaba que los campos de auditoría (created_by, creation_date, last_modified_by, last_modified_date) se perdieran al guardar.

Además se añade detección de cambios reales: si ningún campo editable difiere respecto a BD, el miembro no se incluye en el saveAll, evitando UPDATE innecesarios.

Se elimina también una consulta a BD redundante en la validación de solapamientos que operaba sobre los datos previos  y podía dar falsos positivos.