### PR TITLE
[#71] [BUG][CSP][CON] Preservar campos de auditoría al clonar convocatoria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
 -->
 
 ### Fixed
-- [CSP][CON] Corregida la pérdida de los campos de auditoría de creación (`created_by`, `creation_date`) al modificar una convocatoria y sus entidades relacionadas ([#103](https://github.com/herculesproject/sgi/issues/103)).
-- [CSP][PRO] Corregida la pérdida de los campos de auditoría (`created_by`, `creation_date`, `last_modified_by`, `last_modified_date`) al modificar el equipo de un proyecto. Además, los miembros sin cambios reales ya no generan un UPDATE innecesario en base de datos ([#72](https://github.com/herculesproject/sgi/issues/72)).
+- Los campos `created_by` y `creation_date` de la clase base `Auditable` se marcan ahora como no actualizables (`updatable = false`), impidiendo que Hibernate los sobreescriba y garantizando la inmutabilidad de los datos de auditoría de creación en cualquier entidad ([#71](https://github.com/herculesproject/sgi/issues/71)).
+- [CSP] Corregida la pérdida de los campos de auditoría de creación (`created_by`, `creation_date`) al clonar una convocatoria ([#71](https://github.com/herculesproject/sgi/issues/71)).
+- [CSP] Corregida la pérdida de los campos de auditoría de creación (`created_by`, `creation_date`) al modificar una convocatoria y sus entidades relacionadas ([#103](https://github.com/herculesproject/sgi/issues/103)).
+- [CSP] Corregida la pérdida de los campos de auditoría (`created_by`, `creation_date`, `last_modified_by`, `last_modified_date`) al modificar el equipo de un proyecto. Además, los miembros sin cambios reales ya no generan un UPDATE innecesario en base de datos ([#72](https://github.com/herculesproject/sgi/issues/72)).
 
 ## 1.1.0 (2026-06-11)
 

--- a/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/ConvocatoriaClonerService.java
+++ b/sgi-csp-service/src/main/java/org/crue/hercules/sgi/csp/service/ConvocatoriaClonerService.java
@@ -99,7 +99,8 @@ public class ConvocatoriaClonerService {
         .clasificacionCVN(toClone.getClasificacionCVN())
         .objeto(new HashSet<>(toClone.getObjeto()))
         .observaciones(new HashSet<>(toClone.getObservaciones()))
-        .estado(Convocatoria.Estado.BORRADOR).build();
+        .estado(Convocatoria.Estado.BORRADOR)
+        .build();
   }
 
   /**
@@ -114,8 +115,11 @@ public class ConvocatoriaClonerService {
     convocatoriaAreaTematicaRepository
         .findByConvocatoriaId(convocatoriaId)
         .forEach(convocatoriaAreaTematica -> this.convocatoriaAreaTematicaRepository
-            .save(ConvocatoriaAreaTematica.builder().areaTematica(convocatoriaAreaTematica.getAreaTematica())
-                .convocatoriaId(cloned.getId()).observaciones(convocatoriaAreaTematica.getObservaciones()).build()));
+            .save(ConvocatoriaAreaTematica.builder()
+                .areaTematica(convocatoriaAreaTematica.getAreaTematica())
+                .convocatoriaId(cloned.getId())
+                .observaciones(convocatoriaAreaTematica.getObservaciones())
+                .build()));
   }
 
   /**
@@ -133,8 +137,11 @@ public class ConvocatoriaClonerService {
 
     if (!CollectionUtils.isEmpty(entidadesGestoras)) {
 
-      this.convocatoriaEntidadGestoraRepository.save(ConvocatoriaEntidadGestora.builder()
-          .convocatoriaId(convocatoriaClonedId).entidadRef(entidadesGestoras.get(0).getEntidadRef()).build());
+      this.convocatoriaEntidadGestoraRepository.save(
+          ConvocatoriaEntidadGestora.builder()
+              .convocatoriaId(convocatoriaClonedId)
+              .entidadRef(entidadesGestoras.get(0).getEntidadRef())
+              .build());
     }
   }
 
@@ -151,8 +158,11 @@ public class ConvocatoriaClonerService {
 
     this.convocatoriaEntidadConvocanteRepository.findByConvocatoriaId(convocatoriaToCloneId)
         .forEach(entidad -> this.convocatoriaEntidadConvocanteRepository
-            .save(ConvocatoriaEntidadConvocante.builder().convocatoriaId(convocatoriaClonedId)
-                .entidadRef(entidad.getEntidadRef()).programa(entidad.getPrograma()).build()));
+            .save(ConvocatoriaEntidadConvocante.builder()
+                .convocatoriaId(convocatoriaClonedId)
+                .entidadRef(entidad.getEntidadRef())
+                .programa(entidad.getPrograma())
+                .build()));
   }
 
   /**
@@ -175,10 +185,13 @@ public class ConvocatoriaClonerService {
     this.convocatoriaEntidadFinanciadoraRepository.findByConvocatoriaId(convocatoriaToCloneId)
         .forEach(
             entidad -> this.convocatoriaEntidadFinanciadoraRepository.save(ConvocatoriaEntidadFinanciadora.builder()
-                .convocatoriaId(convocatoriaClonedId).entidadRef(entidad.getEntidadRef())
-                .fuenteFinanciacion(entidad.getFuenteFinanciacion()).tipoFinanciacion(entidad.getTipoFinanciacion())
+                .convocatoriaId(convocatoriaClonedId)
+                .entidadRef(entidad.getEntidadRef())
+                .fuenteFinanciacion(entidad.getFuenteFinanciacion())
+                .tipoFinanciacion(entidad.getTipoFinanciacion())
                 .porcentajeFinanciacion(entidad.getPorcentajeFinanciacion())
-                .importeFinanciacion(entidad.getImporteFinanciacion()).build()));
+                .importeFinanciacion(entidad.getImporteFinanciacion())
+                .build()));
   }
 
   /**
@@ -225,11 +238,15 @@ public class ConvocatoriaClonerService {
     this.convocatoriaPeriodoSeguimientoCientificoRepository
         .findAllByConvocatoriaIdOrderByMesInicial(convocatoriaToCloneId)
         .forEach(periodo -> this.convocatoriaPeriodoSeguimientoCientificoRepository
-            .save(ConvocatoriaPeriodoSeguimientoCientifico.builder().convocatoriaId(convocatoriaClonedId)
+            .save(ConvocatoriaPeriodoSeguimientoCientifico.builder()
+                .convocatoriaId(convocatoriaClonedId)
                 .fechaInicioPresentacion(periodo.getFechaInicioPresentacion())
-                .fechaFinPresentacion(periodo.getFechaFinPresentacion()).mesInicial(periodo.getMesInicial())
-                .mesFinal(periodo.getMesFinal()).numPeriodo(periodo.getNumPeriodo())
-                .tipoSeguimiento(periodo.getTipoSeguimiento()).observaciones(new HashSet<>(periodo.getObservaciones()))
+                .fechaFinPresentacion(periodo.getFechaFinPresentacion())
+                .mesInicial(periodo.getMesInicial())
+                .mesFinal(periodo.getMesFinal())
+                .numPeriodo(periodo.getNumPeriodo())
+                .tipoSeguimiento(periodo.getTipoSeguimiento())
+                .observaciones(new HashSet<>(periodo.getObservaciones()))
                 .build()));
   }
 
@@ -279,14 +296,18 @@ public class ConvocatoriaClonerService {
 
   private RequisitoIP createRequisitoIP(RequisitoIP requisito, Long convocatoriaClonedId) {
 
-    return RequisitoIP.builder().id(convocatoriaClonedId).numMaximoIP(requisito.getNumMaximoIP())
-        .edadMaxima(requisito.getEdadMaxima()).sexoRef(requisito.getSexoRef())
+    return RequisitoIP.builder()
+        .id(convocatoriaClonedId)
+        .numMaximoIP(requisito.getNumMaximoIP())
+        .edadMaxima(requisito.getEdadMaxima())
+        .sexoRef(requisito.getSexoRef())
         .vinculacionUniversidad(requisito.getVinculacionUniversidad())
         .numMinimoCompetitivos(requisito.getNumMinimoCompetitivos())
         .numMinimoNoCompetitivos(requisito.getNumMinimoNoCompetitivos())
         .numMaximoCompetitivosActivos(requisito.getNumMaximoCompetitivosActivos())
         .numMaximoNoCompetitivosActivos(requisito.getNumMaximoNoCompetitivosActivos())
-        .otrosRequisitos(requisito.getOtrosRequisitos()).build();
+        .otrosRequisitos(requisito.getOtrosRequisitos())
+        .build();
   }
 
   /**
@@ -302,7 +323,9 @@ public class ConvocatoriaClonerService {
   private void cloneRequisitoIPNivelesAcademicos(Long requisitoIPToClneId, Long requisitoIPClonedId) {
     this.requisitoIPNivelAcademicoRepository.findByRequisitoIPId(requisitoIPToClneId)
         .forEach(nivel -> this.requisitoIPNivelAcademicoRepository.save(RequisitoIPNivelAcademico.builder()
-            .requisitoIPId(requisitoIPClonedId).nivelAcademicoRef(nivel.getNivelAcademicoRef()).build()));
+            .requisitoIPId(requisitoIPClonedId)
+            .nivelAcademicoRef(nivel.getNivelAcademicoRef())
+            .build()));
   }
 
   /**
@@ -318,8 +341,10 @@ public class ConvocatoriaClonerService {
   private void cloneRequisitoIPCategoriasProfesionales(Long requisitoIPToClneId, Long requisitoIPClonedId) {
     this.requisitoIPCategoriaProfesionalRepository.findByRequisitoIPId(requisitoIPToClneId)
         .forEach(categoria -> this.requisitoIPCategoriaProfesionalRepository
-            .save(RequisitoIPCategoriaProfesional.builder().requisitoIPId(requisitoIPClonedId)
-                .categoriaProfesionalRef(categoria.getCategoriaProfesionalRef()).build()));
+            .save(RequisitoIPCategoriaProfesional.builder()
+                .requisitoIPId(requisitoIPClonedId)
+                .categoriaProfesionalRef(categoria.getCategoriaProfesionalRef())
+                .build()));
   }
 
   /**
@@ -363,13 +388,18 @@ public class ConvocatoriaClonerService {
 
   private RequisitoEquipo createRequisitoEquipo(Long convocatoriaClonedId, RequisitoEquipo requisito) {
 
-    return RequisitoEquipo.builder().edadMaxima(requisito.getEdadMaxima()).sexoRef(requisito.getSexoRef())
-        .ratioSexo(requisito.getRatioSexo()).vinculacionUniversidad(requisito.getVinculacionUniversidad())
+    return RequisitoEquipo.builder()
+        .edadMaxima(requisito.getEdadMaxima())
+        .sexoRef(requisito.getSexoRef())
+        .ratioSexo(requisito.getRatioSexo())
+        .vinculacionUniversidad(requisito.getVinculacionUniversidad())
         .numMinimoCompetitivos(requisito.getNumMinimoCompetitivos())
         .numMinimoNoCompetitivos(requisito.getNumMinimoNoCompetitivos())
         .numMaximoCompetitivosActivos(requisito.getNumMaximoNoCompetitivosActivos())
         .numMaximoNoCompetitivosActivos(requisito.getNumMaximoNoCompetitivosActivos())
-        .otrosRequisitos(requisito.getOtrosRequisitos()).id(convocatoriaClonedId).build();
+        .otrosRequisitos(requisito.getOtrosRequisitos())
+        .id(convocatoriaClonedId)
+        .build();
   }
 
   /**
@@ -386,7 +416,9 @@ public class ConvocatoriaClonerService {
   private void cloneRequisitoEquipoNivelesAcademicos(Long requisitoEquipoToClneId, Long requisitoEquipoClonedId) {
     this.requisitoEquipoNivelAcademicoRepository.findByRequisitoEquipoId(requisitoEquipoToClneId)
         .forEach(nivel -> this.requisitoEquipoNivelAcademicoRepository.save(RequisitoEquipoNivelAcademico.builder()
-            .requisitoEquipoId(requisitoEquipoClonedId).nivelAcademicoRef(nivel.getNivelAcademicoRef()).build()));
+            .requisitoEquipoId(requisitoEquipoClonedId)
+            .nivelAcademicoRef(nivel.getNivelAcademicoRef())
+            .build()));
   }
 
   /**
@@ -403,8 +435,10 @@ public class ConvocatoriaClonerService {
   private void cloneRequisitoEquipoCategoriasProfesionales(Long requisitoEquipoToClneId, Long requisitoEquipoClonedId) {
     this.requisitoEquipoCategoriaProfesionalRepository.findByRequisitoEquipoId(requisitoEquipoToClneId)
         .forEach(categoria -> this.requisitoEquipoCategoriaProfesionalRepository
-            .save(RequisitoEquipoCategoriaProfesional.builder().requisitoEquipoId(requisitoEquipoClonedId)
-                .categoriaProfesionalRef(categoria.getCategoriaProfesionalRef()).build()));
+            .save(RequisitoEquipoCategoriaProfesional.builder()
+                .requisitoEquipoId(requisitoEquipoClonedId)
+                .categoriaProfesionalRef(categoria.getCategoriaProfesionalRef())
+                .build()));
   }
 
   /**
@@ -446,17 +480,23 @@ public class ConvocatoriaClonerService {
     return ConvocatoriaConceptoGastoCodigoEc.builder()
         .convocatoriaConceptoGastoId(clonedConvocatoriaConceptoGasto.getId())
         .codigoEconomicoRef(convConceptoGastoCodEc.getCodigoEconomicoRef())
-        .fechaInicio(convConceptoGastoCodEc.getFechaInicio()).fechaFin(convConceptoGastoCodEc.getFechaFin())
-        .observaciones(new HashSet<>(convConceptoGastoCodEc.getObservaciones())).build();
+        .fechaInicio(convConceptoGastoCodEc.getFechaInicio())
+        .fechaFin(convConceptoGastoCodEc.getFechaFin())
+        .observaciones(new HashSet<>(convConceptoGastoCodEc.getObservaciones()))
+        .build();
   }
 
   private ConvocatoriaConceptoGasto createConvocatoriaConceptoGasto(Long convocatoriaClonedId,
       ConvocatoriaConceptoGasto convConceptoGasto) {
-    return ConvocatoriaConceptoGasto.builder().convocatoriaId(convocatoriaClonedId)
-        .mesInicial(convConceptoGasto.getMesInicial()).mesFinal(convConceptoGasto.getMesFinal())
+    return ConvocatoriaConceptoGasto.builder()
+        .convocatoriaId(convocatoriaClonedId)
+        .mesInicial(convConceptoGasto.getMesInicial())
+        .mesFinal(convConceptoGasto.getMesFinal())
         .importeMaximo(convConceptoGasto.getImporteMaximo())
         .observaciones(new HashSet<>(convConceptoGasto.getObservaciones()))
-        .permitido(convConceptoGasto.getPermitido()).conceptoGasto(convConceptoGasto.getConceptoGasto()).build();
+        .permitido(convConceptoGasto.getPermitido())
+        .conceptoGasto(convConceptoGasto.getConceptoGasto())
+        .build();
   }
 
   /**

--- a/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaIT.java
+++ b/sgi-csp-service/src/test/java/org/crue/hercules/sgi/csp/integration/ConvocatoriaIT.java
@@ -1807,7 +1807,17 @@ class ConvocatoriaIT extends BaseIT {
 
     // then: se devuelve HTTP 201 con el id de la Convocatoria clonada
     Assertions.assertThat(cloneResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-    Assertions.assertThat(cloneResponse.getBody()).isNotNull();
+    Long clonedId = cloneResponse.getBody();
+    Assertions.assertThat(clonedId).isNotNull();
+
+    // and: la convocatoria clonada tiene los campos de auditoría rellenos
+    final ResponseEntity<Convocatoria> getResponse = restTemplate.exchange(
+        CONTROLLER_BASE_PATH + PATH_PARAMETER_ID,
+        HttpMethod.GET, buildRequest(null, null), Convocatoria.class, clonedId);
+    Assertions.assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    Convocatoria clonada = getResponse.getBody();
+    Assertions.assertThat(clonada.getCreatedBy()).as("getCreatedBy()").isNotNull();
+    Assertions.assertThat(clonada.getCreationDate()).as("getCreationDate()").isNotNull();
   }
 
   @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {
@@ -1831,13 +1841,23 @@ class ConvocatoriaIT extends BaseIT {
         .fromUriString(CONTROLLER_BASE_PATH + PATH_PARAMETER_ID + PATH_CLONE)
         .buildAndExpand(convocatoriaId).toUri();
 
-    final ResponseEntity<Long> response = restTemplate.exchange(uri,
+    final ResponseEntity<Long> cloneResponse = restTemplate.exchange(uri,
         HttpMethod.POST,
         buildGenericRequest(null, null, "CSP-CON-C"), Long.class);
 
     // then: se devuelve HTTP 201 con el id de la Convocatoria clonada
-    Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-    Assertions.assertThat(response.getBody()).isNotNull();
+    Assertions.assertThat(cloneResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    Long clonedId = cloneResponse.getBody();
+    Assertions.assertThat(clonedId).isNotNull();
+
+    // and: la convocatoria clonada tiene los campos de auditoría rellenos
+    final ResponseEntity<Convocatoria> getResponse = restTemplate.exchange(
+        CONTROLLER_BASE_PATH + PATH_PARAMETER_ID,
+        HttpMethod.GET, buildRequest(null, null), Convocatoria.class, clonedId);
+    Assertions.assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    Convocatoria clonada = getResponse.getBody();
+    Assertions.assertThat(clonada.getCreatedBy()).as("getCreatedBy()").isNotNull();
+    Assertions.assertThat(clonada.getCreationDate()).as("getCreationDate()").isNotNull();
   }
 
   @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {

--- a/sgi-framework-spring/src/main/java/org/crue/hercules/sgi/framework/data/jpa/domain/Auditable.java
+++ b/sgi-framework-spring/src/main/java/org/crue/hercules/sgi/framework/data/jpa/domain/Auditable.java
@@ -2,6 +2,7 @@ package org.crue.hercules.sgi.framework.data.jpa.domain;
 
 import java.time.Instant;
 
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 
@@ -26,10 +27,12 @@ import lombok.experimental.SuperBuilder;
 public abstract class Auditable {
   /** Creator */
   @CreatedBy
+  @Column(name = "created_by", updatable = false)
   protected String createdBy;
 
   /** Creation date */
   @CreatedDate
+  @Column(name = "creation_date", updatable = false)
   protected Instant creationDate;
 
   /** Last updater */


### PR DESCRIPTION
Al clonar una convocatoria, los campos createdBy y creationDate quedaban a null en la convocatoria. La entidad se construía mediante un builder sin dichos campos, que eran asignados por el listener de auditoría de Spring Data en el @PrePersist. Sin embargo, durante el mismo ciclo de flush, Hibernate podía emitir sentencias UPDATE adicionales sobre esa entidad que sobreescribían los campos de auditoría con null al tomar como referencia el estado original del objeto en memoria (donde esos campos eran null).

Se añade @Column(updatable = false) a los campos createdBy y creationDate de la clase base Auditable (sgi-framework-spring), de forma que Hibernate los excluya de cualquier sentencia UPDATE. Al ser Auditable la superclase de todas las entidades auditables de la aplicación, esta corrección aplica de forma global y previene la pérdida de datos de auditoría de creación en cualquier entidad del sistema.