### PR TITLE
[#108] [BUG][CSP][SOL] Reordenar columnas de unidades de vinculación y renombrar variable de configuración

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
        ### Security         Correcciones de vulnerabilidades
 -->
 
+### Changed
+- [CSP] Reordenadas las columnas de la exportación de solicitudes: el bloque de unidades de vinculación se muestra ahora antes de las columnas "Datos Solicitud RRHH" y sus columnas llevan el prefijo "Datos Proyecto", igual que el resto de columnas de las solicitudes de tipo proyecto ([#108](https://github.com/herculesproject/sgi/issues/108)).
+- [CSP] Renombrada la etiqueta de la variable de configuración de unidades de vinculación para proyectos a "Habilitar unidades de vinculación para Proyectos y Solicitudes" para reflejar que también aplica a las solicitudes ([#108](https://github.com/herculesproject/sgi/issues/108)).
+
 ### Fixed
 - Los campos `created_by` y `creation_date` de la clase base `Auditable` se marcan ahora como no actualizables (`updatable = false`), impidiendo que Hibernate los sobreescriba y garantizando la inmutabilidad de los datos de auditoría de creación en cualquier entidad ([#71](https://github.com/herculesproject/sgi/issues/71)).
 - [CSP] Corregida la pérdida de los campos de auditoría de creación (`created_by`, `creation_date`) al clonar una convocatoria ([#71](https://github.com/herculesproject/sgi/issues/71)).

--- a/sgi-webapp/src/app/module/csp/solicitud/solicitud-listado-export.service.ts
+++ b/sgi-webapp/src/app/module/csp/solicitud/solicitud-listado-export.service.ts
@@ -162,14 +162,14 @@ export class SolicitudListadoExportService extends AbstractTableExportService<IS
         if (reportConfig.reportOptions?.showSolicitudProyectoEntidadesFinanciadoras) {
           row.elements.push(...this.solicitudProyectoEntidadFinanciadoraListadoExportService.fillRows(solicitudes, index, reportConfig));
         }
+        if (reportConfig.reportOptions?.showSolicitudProyectoUnidadesVinculacion) {
+          row.elements.push(...this.solicitudProyectoUnidadVinculacionListadoExportService.fillRows(solicitudes, index, reportConfig));
+        }
         if (reportConfig.reportOptions?.showSolicitudRrhh) {
           row.elements.push(...this.solicitudRrhhListadoExportService.fillRows(solicitudes, index, reportConfig));
         }
         if (reportConfig.reportOptions?.showGruposInvestigacionIps) {
           row.elements.push(...this.solicitudGruposInvestigacionIpListadoExportService.fillRows(solicitudes, index, reportConfig));
-        }
-        if (reportConfig.reportOptions?.showSolicitudProyectoUnidadesVinculacion) {
-          row.elements.push(...this.solicitudProyectoUnidadVinculacionListadoExportService.fillRows(solicitudes, index, reportConfig));
         }
         return row;
       })
@@ -419,14 +419,14 @@ export class SolicitudListadoExportService extends AbstractTableExportService<IS
     if (reportConfig.reportOptions?.showSolicitudProyectoEntidadesFinanciadoras) {
       columns.push(... this.solicitudProyectoEntidadFinanciadoraListadoExportService.fillColumns(resultados, reportConfig));
     }
+    if (reportConfig.reportOptions?.showSolicitudProyectoUnidadesVinculacion) {
+      columns.push(... this.solicitudProyectoUnidadVinculacionListadoExportService.fillColumns(resultados, reportConfig));
+    }
     if (reportConfig.reportOptions?.showSolicitudRrhh) {
       columns.push(... this.solicitudRrhhListadoExportService.fillColumns(resultados, reportConfig));
     }
     if (reportConfig.reportOptions?.showGruposInvestigacionIps) {
       columns.push(... this.solicitudGruposInvestigacionIpListadoExportService.fillColumns(resultados, reportConfig));
-    }
-    if (reportConfig.reportOptions?.showSolicitudProyectoUnidadesVinculacion) {
-      columns.push(... this.solicitudProyectoUnidadVinculacionListadoExportService.fillColumns(resultados, reportConfig));
     }
     return of(columns);
   }

--- a/sgi-webapp/src/app/module/csp/solicitud/solicitud-proyecto-unidad-vinculacion-listado-export.service.ts
+++ b/sgi-webapp/src/app/module/csp/solicitud/solicitud-proyecto-unidad-vinculacion-listado-export.service.ts
@@ -19,6 +19,7 @@ import { ISolicitudReportData, ISolicitudReportOptions } from './solicitud-lista
 const UNIDAD_KEY = marker('csp.solicitud-proyecto-unidad-vinculacion');
 const TIPO_UNIDAD_KEY = marker('csp.solicitud-proyecto-unidad-vinculacion.tipo-unidad');
 const VALOR_KEY = marker('csp.solicitud-proyecto-unidad-vinculacion.valor');
+const PROYECTO_KEY = marker('menu.csp.solicitudes.datos-proyecto');
 
 const TIPO_UNIDAD_FIELD = 'tipoUnidad';
 const UNIDAD_FIELD = 'unidad';
@@ -152,6 +153,7 @@ export class SolicitudProyectoUnidadVinculacionListadoExportService
 
   private getColumnsUnidadExcel(solicitudes: ISolicitudReportData[]): ISgiColumnReport[] {
     const columns: ISgiColumnReport[] = [];
+    const titleDatosProyecto = this.translate.instant(PROYECTO_KEY);
     const titleUnidadesVinculacion = this.translate.instant(UNIDAD_KEY, MSG_PARAMS.CARDINALIRY.PLURAL);
     const titleTipo = this.translate.instant(TIPO_UNIDAD_KEY);
     const titleValor = this.translate.instant(VALOR_KEY);
@@ -161,7 +163,7 @@ export class SolicitudProyectoUnidadVinculacionListadoExportService
 
       columns.push({
         name: TIPO_UNIDAD_FIELD + indexTipo,
-        title: `${titleUnidadesVinculacion} ${indexTipo}: ${titleTipo}`,
+        title: `${titleDatosProyecto}: ${titleUnidadesVinculacion} ${indexTipo}: ${titleTipo}`,
         type: ColumnType.STRING,
       });
 
@@ -170,7 +172,7 @@ export class SolicitudProyectoUnidadVinculacionListadoExportService
         const indexValor = String(j + 1);
         columns.push({
           name: `${UNIDAD_FIELD}${indexTipo}_${indexValor}`,
-          title: `${titleUnidadesVinculacion} ${indexTipo}: ${titleValor} ${indexValor}`,
+          title: `${titleDatosProyecto}: ${titleUnidadesVinculacion} ${indexTipo}: ${titleValor} ${indexValor}`,
           type: ColumnType.STRING,
         });
       }

--- a/sgi-webapp/src/assets/i18n/ca.json
+++ b/sgi-webapp/src/assets/i18n/ca.json
@@ -86,7 +86,7 @@
   "adm.config.csp.CSP_PROYECTO_SGE_MODIFICACION_MODO_EJECUCION.description": "Paràmetre que permet configurar si la modificació del projecte econòmic a l'SGE es realitza de forma sincrona o de forma asíncrona",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED": "Habilitar el paràmetre de cerca per país de soci al cercador ampliat de projectes",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED.description": "Habilitar el paràmetre de cerca per país de soci al cercador ampliat de projectes",
-  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Habilitar les unitats de vinculació per als Projectes",
+  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Habilitar les unitats de vinculació per als Projectes i Sol·licituds",
   "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED.description": "Habilitar l'apartat d'unitats de vinculació en el formulari de Projectes",
   "adm.config.csp.CSP_REP_PROYECTO_EXT_CERTIFICADO_AUTORIZACION_DOCX": "Plantilla informe dautorització de participació en projecte extern",
   "adm.config.csp.CSP_SECTOR_IVA_SGE_ENABLED": "Habilitar camp Sector IVA del SGE",

--- a/sgi-webapp/src/assets/i18n/en.json
+++ b/sgi-webapp/src/assets/i18n/en.json
@@ -86,7 +86,7 @@
   "adm.config.csp.CSP_PROYECTO_SGE_MODIFICACION_MODO_EJECUCION.description": "Parameter to configure whether the modification of the financial project in the SGE is done synchronously or asynchronously.",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED": "Allow the partner country search parameter in the extended project search engine",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED.description": "Allow the partner country search parameter in the extended project search engine",
-  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Enable linking units for Projects",
+  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Enable linking units for Projects and Applications",
   "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED.description": "Enable the linking units section of Projects",
   "adm.config.csp.CSP_REP_PROYECTO_EXT_CERTIFICADO_AUTORIZACION_DOCX": "Template for external project participation authorisation report",
   "adm.config.csp.CSP_SECTOR_IVA_SGE_ENABLED": "Enable SGE VAT Sector field",

--- a/sgi-webapp/src/assets/i18n/es.json
+++ b/sgi-webapp/src/assets/i18n/es.json
@@ -90,7 +90,7 @@
   "adm.config.csp.CSP_PROYECTO_SGE_MODIFICACION_MODO_EJECUCION.description": "Parámetro que permite configurar si la modificación del proyecto económico en el SGE se realiza de forma sincrona o de forma asíncrona",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED": "Habilitar el parámetro de búsqueda por país de socio en el buscador ampliado de proyectos",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED.description": "Habilitar el parámetro de búsqueda por país de socio en el buscador ampliado de proyectos",
-  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Habilitar unidades de vinculación para Proyectos",
+  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Habilitar unidades de vinculación para Proyectos y Solicitudes",
   "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED.description": "Habilitar el apartado de unidades de vinculación de Proyectos",
   "adm.config.csp.CSP_REP_PROYECTO_EXT_CERTIFICADO_AUTORIZACION_DOCX": "Plantilla informe de autorización de participación en proyecto externo",
   "adm.config.csp.CSP_SECTOR_IVA_SGE_ENABLED": "Habilitar campo Sector IVA del SGE",

--- a/sgi-webapp/src/assets/i18n/eu.json
+++ b/sgi-webapp/src/assets/i18n/eu.json
@@ -86,7 +86,7 @@
   "adm.config.csp.CSP_PROYECTO_SGE_MODIFICACION_MODO_EJECUCION.description": "Proiektu ekonomikoaren aldaketa KESan modu sinkronoan ala asinkronoan egiten den konfiguratzeko aukera ematen duen parametroa",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED": "Proiektuen bilatzaile zabalduan bazkidearen herrialdearen araberako bilaketa parametroa gaitzea",
   "adm.config.csp.CSP_PROYECTO_SOCIO_PAIS_FILTER_ENABLED.description": "Proiektuen bilatzaile zabalduan bazkidearen herrialdearen araberako bilaketa parametroa gaitzea",
-  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Proiektuen lotura unitateak gaitzea",
+  "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED": "Proiektuen eta eskaeren lotura unitateak gaitzea",
   "adm.config.csp.CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED.description": "Proiektuen lotura unitateen atala gaitzea",
   "adm.config.csp.CSP_REP_PROYECTO_EXT_CERTIFICADO_AUTORIZACION_DOCX": "Kanpo proiektuetako partaidetza baimentzeko txostenaren txantiloia",
   "adm.config.csp.CSP_SECTOR_IVA_SGE_ENABLED": "KESko BEZ sektorearen eremua gaitzea",


### PR DESCRIPTION
- El bloque de columnas de unidades de vinculación pasa a mostrarse antes de las columnas "Datos Solicitud RRHH".
- Las columnas de unidades de vinculación llevan ahora el prefijo "Datos Proyecto", igual que el resto de columnas de las solicitudes de tipo proyecto.
- Se renombra la etiqueta de la variable de configuración CSP_PROYECTO_UNIDADES_VINCULACION_ENABLED a "Habilitar  unidades de vinculación para Proyectos y Solicitudes"